### PR TITLE
Update gitignore

### DIFF
--- a/shopware/core/6.4/config/jwt/.gitignore
+++ b/shopware/core/6.4/config/jwt/.gitignore
@@ -1,0 +1,3 @@
+*
+
+!.gitignore


### PR DESCRIPTION
Necessary change because otherwise private and public.pem key get pushed in the repo
