### PR TITLE
exclude sensitive information from your repository

### DIFF
--- a/shopware/core/6.4/manifest.json
+++ b/shopware/core/6.4/manifest.json
@@ -47,6 +47,7 @@
         "MAILER_URL": "null://null"
     },
     "gitignore": [
+        ".env*",
         "custom/*",
         "!custom/plugins/.gitkeep",
         "!custom/static-plugins/",


### PR DESCRIPTION
.env often includes sensitive information like database credentials and API keys, it is a best practice to exclude this information from your repository