### PR TITLE
feat: add monolog override

### DIFF
--- a/symfony/monolog-bundle/3.3/config/packages/dev/monolog.yaml
+++ b/symfony/monolog-bundle/3.3/config/packages/dev/monolog.yaml
@@ -1,0 +1,19 @@
+monolog:
+    handlers:
+        main:
+            type: stream
+            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            level: debug
+            channels: ["!event"]
+        # uncomment to get logging in your browser
+        # you may have to allow bigger header sizes in your Web server configuration
+        #firephp:
+        #    type: firephp
+        #    level: info
+        #chromephp:
+        #    type: chromephp
+        #    level: info
+        console:
+            type: console
+            process_psr_3_messages: false
+            channels: ["!event", "!doctrine", "!console"]

--- a/symfony/monolog-bundle/3.3/config/packages/prod/deprecations.yaml
+++ b/symfony/monolog-bundle/3.3/config/packages/prod/deprecations.yaml
@@ -1,0 +1,8 @@
+# As of Symfony 5.1, deprecations are logged in the dedicated "deprecation" channel when it exists
+#monolog:
+#    channels: [deprecation]
+#    handlers:
+#        deprecation:
+#            type: stream
+#            channels: [deprecation]
+#            path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"

--- a/symfony/monolog-bundle/3.3/config/packages/prod/monolog.yaml
+++ b/symfony/monolog-bundle/3.3/config/packages/prod/monolog.yaml
@@ -1,0 +1,18 @@
+monolog:
+    handlers:
+        main:
+            type: fingers_crossed
+            action_level: error
+            handler: nested
+            excluded_http_codes: [404, 405]
+            buffer_size: 30 # How many messages should be saved? Prevent memory leaks
+        business_event_handler_buffer:
+            level: error
+        nested:
+            type: rotating_file
+            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            level: error
+        console:
+            type: console
+            process_psr_3_messages: false
+            channels: ["!event", "!doctrine"]

--- a/symfony/monolog-bundle/3.3/config/packages/test/monolog.yaml
+++ b/symfony/monolog-bundle/3.3/config/packages/test/monolog.yaml
@@ -1,0 +1,12 @@
+monolog:
+    handlers:
+        main:
+            type: fingers_crossed
+            action_level: error
+            handler: nested
+            excluded_http_codes: [404, 405]
+            channels: ["!event"]
+        nested:
+            type: stream
+            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            level: debug

--- a/symfony/monolog-bundle/3.3/manifest.json
+++ b/symfony/monolog-bundle/3.3/manifest.json
@@ -1,0 +1,9 @@
+{
+    "bundles": {
+        "Symfony\\Bundle\\MonologBundle\\MonologBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "aliases": ["log", "logger", "logging", "logs", "monolog"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

overrides monolog recipe to respect [shopware performance tweaks](https://developer.shopware.com/docs/guides/hosting/performance/performance-tweaks#logging) and sets the logging type to `rotating_file` like the shopware default (only in prod)