### PR TITLE
Export PROXY_URL in watch-storefront.sh scripts

### DIFF
--- a/shopware/platform/6.4/bin/watch-storefront.sh
+++ b/shopware/platform/6.4/bin/watch-storefront.sh
@@ -11,6 +11,7 @@ source "${PROJECT_ROOT}/bin/functions.sh"
 load_dotenv "$ENV_FILE"
 
 export APP_URL
+export PROXY_URL
 export STOREFRONT_PROXY_PORT
 export ESLINT_DISABLE
 

--- a/shopware/storefront/6.4/bin/watch-storefront.sh
+++ b/shopware/storefront/6.4/bin/watch-storefront.sh
@@ -11,6 +11,7 @@ source "${PROJECT_ROOT}/bin/functions.sh"
 load_dotenv "$ENV_FILE"
 
 export APP_URL
+export PROXY_URL
 export STOREFRONT_PROXY_PORT
 export ESLINT_DISABLE
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

The hot reload proxy of `shopware/storefront` accepts a `PROXY_URL` environment variable which is currently not exported in the `watch-storefront.sh` script.

I'm using shopware in a DDEV setup with the hot proxy running on my host, so my proxy host and shopware host differ and the fallback to `APP_URL` no longer works.

But nevertheless, the hot proxy supports that variable so why not give it access to it ;) 

See: https://github.com/shopware/platform/blob/cfc39359c140edd71619b003779840b3499840fa/src/Storefront/Resources/app/storefront/build/start-hot-reload.js#L9

I'm not sure weather the "default" `watch-storefront.sh` script is affected by that.
I doesn't export `PROXY_URL`neither but I haven't tested it with a "default" shopware setup, just with the symfony/flex one in combination with DDEV. I'd be willing to submit a PR against `shopware/platform` to add the export there also if they are also affected :)

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->