### PR TITLE
Add environment variable to skip feature:dump when building the storefront

### DIFF
--- a/shopware/platform/6.4/bin/build-storefront.sh
+++ b/shopware/platform/6.4/bin/build-storefront.sh
@@ -20,7 +20,7 @@ fi
 
 # build storefront
 [[ ${SHOPWARE_SKIP_BUNDLE_DUMP-""} ]] || "${BIN_TOOL}" bundle:dump
-DATABASE_URL="" "${BIN_TOOL}" feature:dump
+[[ ${SHOPWARE_SKIP_FEATURE_DUMP-""} ]] || DATABASE_URL="" "${BIN_TOOL}" feature:dump
 
 if [[ $(command -v jq) ]]; then
     OLDPWD=$(pwd)

--- a/shopware/storefront/6.4/bin/build-storefront.sh
+++ b/shopware/storefront/6.4/bin/build-storefront.sh
@@ -20,7 +20,7 @@ fi
 
 # build storefront
 [[ ${SHOPWARE_SKIP_BUNDLE_DUMP-""} ]] || "${BIN_TOOL}" bundle:dump
-DATABASE_URL="" "${BIN_TOOL}" feature:dump
+[[ ${SHOPWARE_SKIP_FEATURE_DUMP-""} ]] || DATABASE_URL="" "${BIN_TOOL}" feature:dump
 
 if [[ $(command -v jq) ]]; then
     OLDPWD=$(pwd)


### PR DESCRIPTION
**What was changed?**

I added the check for a new environment variable `SHOPWARE_SKIP_FEATURE_DUMP` so that the call of the `feature:dump` command in the script `bin/build-storefront.sh` can be skipped. All other console calls already had such an environment variable, only for the `feature:dump` it was missing.

**Why is this necessary?**

During a deployment the `feature:dump` command is not necessarily needed, because according to its own description it is meant for js testing and hot reloading. Thus, it should not be a problem to skip the command, if you don't need this things during deployment. Since it is the only PHP call that cannot be skipped, it is mandatory to have an environment where PHP is installed. If you can skip this command as well, you don't need to have PHP installed to build the storefront and then the normal "node" Docker image will suffice, for example. And this simplifies our Gitlab deployment pipeline.
