### PR TITLE
Disable stale_while_revalidate on SHIELD node

### DIFF
--- a/shopware/fastly-meta/6.4/config/fastly/recv.vcl
+++ b/shopware/fastly-meta/6.4/config/fastly/recv.vcl
@@ -59,3 +59,8 @@ if (req.http.Authenticate || req.http.Authorization) {
 if (req.url.path ~ "^/(checkout|account|admin|api|csrf)(/.*)?$") {
     set req.http.x-pass = "1";
 }
+
+# Disable stale_while_revalidate feature on SHIELD node to avoid caching issue when both soft-purges and shieding are used.
+if (fastly.ff.visits_this_service > 0) {
+  set req.max_stale_while_revalidate = 0s;
+}


### PR DESCRIPTION
Disable stale_while_revalidate feature on Fastly SHIELD node to avoid caching issue when both soft-purges and shieding are used. Otherwise, it could happen that the SHIELD returns a stale object right after the purge request has been received, and the POP will cache this stale content if the Age<Max-Age.