### PR TITLE
Skip npm dependency installation if skipping env var isset

### DIFF
--- a/shopware/administration/6.4/bin/build-administration.sh
+++ b/shopware/administration/6.4/bin/build-administration.sh
@@ -33,6 +33,12 @@ if [[ $(command -v jq) ]]; then
         path=$(dirname "$srcPath")
         name=$(echo "$config" | jq -r '.technicalName' )
 
+        skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
+
+        if [[ ${!skippingEnvVarName-""} ]]; then
+            continue
+        fi
+
         if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "administration" ]]; then
             echo "=> Installing npm dependencies for ${name}"
 

--- a/shopware/administration/6.4/bin/watch-administration.sh
+++ b/shopware/administration/6.4/bin/watch-administration.sh
@@ -36,6 +36,12 @@ if [[ $(command -v jq) ]]; then
         path=$(dirname "$srcPath")
         name=$(echo "$config" | jq -r '.technicalName' )
 
+        skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
+
+        if [[ ${!skippingEnvVarName-""} ]]; then
+            continue
+        fi
+
         if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "administration" ]]; then
             echo "=> Installing npm dependencies for ${name}"
 

--- a/shopware/storefront/6.4/bin/build-storefront.sh
+++ b/shopware/storefront/6.4/bin/build-storefront.sh
@@ -33,6 +33,12 @@ if [[ $(command -v jq) ]]; then
         path=$(dirname "$srcPath")
         name=$(echo "$config" | jq -r '.technicalName' )
 
+        skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
+
+        if [[ ${!skippingEnvVarName-""} ]]; then
+            continue
+        fi
+
         if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "storefront" ]]; then
             echo "=> Installing npm dependencies for ${name}"
 

--- a/shopware/storefront/6.4/bin/watch-storefront.sh
+++ b/shopware/storefront/6.4/bin/watch-storefront.sh
@@ -37,6 +37,12 @@ if [[ $(command -v jq) ]]; then
         path=$(dirname "$srcPath")
         name=$(echo "$config" | jq -r '.technicalName' )
 
+        skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
+
+        if [[ ${!skippingEnvVarName-""} ]]; then
+            continue
+        fi
+
         if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "storefront" ]]; then
             echo "=> Installing npm dependencies for ${name}"
 


### PR DESCRIPTION
Based on the [pull request](https://github.com/shopware/webpack-plugin-injector/pull/4) it would be nice if the dependency installation is also skipped if the matching environment variable isset.