### PR TITLE
Add environment variable to skip entity schema dump when building adm…

### DIFF
--- a/shopware/administration/6.4/bin/build-administration.sh
+++ b/shopware/administration/6.4/bin/build-administration.sh
@@ -53,7 +53,7 @@ fi
 (cd "${ADMIN_ROOT}"/Resources/app/administration && npm install --no-audit --prefer-offline)
 
 # Dump entity schema
-if [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
+if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
   mkdir -p "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_
   "${BIN_TOOL}" -e prod framework:schema -s 'entity-schema' "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_/entity-schema.json
   (cd "${ADMIN_ROOT}"/Resources/app/administration && npm run convert-entity-schema)

--- a/shopware/platform/6.4/bin/build-administration.sh
+++ b/shopware/platform/6.4/bin/build-administration.sh
@@ -53,7 +53,7 @@ fi
 (cd "${ADMIN_ROOT}"/Resources/app/administration && npm install --no-audit --prefer-offline)
 
 # Dump entity schema
-if [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
+if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
   mkdir -p "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_
   "${BIN_TOOL}" -e prod framework:schema -s 'entity-schema' "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_/entity-schema.json
   (cd "${ADMIN_ROOT}"/Resources/app/administration && npm run convert-entity-schema)


### PR DESCRIPTION
**What was changed?**

I added the check for a new environment variable `SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP` so that the dump of the entity schema in the script `bin/build-administration.sh` can be skipped. All other console calls already had such an environment variable, only for the dump of the entity schema it was missing.

**Why is this necessary?**

During a deployment the dump of the entity schema is not necessarily needed, because it is meant for js testing (if I see it correctly). Thus, it should not be a problem to skip the part, if you don't need this tests during deployment. Since it is the only PHP call that cannot be skipped, it is mandatory to have an environment where PHP is installed. If you can skip this command as well, you don't need to have PHP installed to build the administration and then the normal "node" Docker image will suffice, for example. And this simplifies our Gitlab deployment pipeline.

I already made a similar change a few months ago for the storefront script: https://github.com/shopware/recipes/pull/32
It would be nice if in the future further calls to the console can be skipped directly with an environment variable.