### PR TITLE
Devenv Environment variables: Use 127.0.0.1 instead of localhost

### DIFF
--- a/frosh/devenv-meta/0.1/root/devenv.nix
+++ b/frosh/devenv-meta/0.1/root/devenv.nix
@@ -95,8 +95,8 @@
   #services.elasticsearch.enable = true;
 
   # Environment variables
-  env.MAILER_DSN = lib.mkDefault "smtp://localhost:1025";
-  env.DATABASE_URL = lib.mkDefault "mysql://shopware:shopware@localhost:3306/shopware";
+  env.MAILER_DSN = lib.mkDefault "smtp://127.0.0.1:1025";
+  env.DATABASE_URL = lib.mkDefault "mysql://shopware:shopware@127.0.0.1:3306/shopware";
 
   # Webpack compatibility
   env.NODE_OPTIONS = lib.mkDefault "--openssl-legacy-provider";

--- a/frosh/devenv-meta/0.2/root/devenv.nix
+++ b/frosh/devenv-meta/0.2/root/devenv.nix
@@ -95,8 +95,8 @@
   #services.elasticsearch.enable = true;
 
   # Environment variables
-  env.MAILER_DSN = lib.mkDefault "smtp://localhost:1025";
-  env.DATABASE_URL = lib.mkDefault "mysql://shopware:shopware@localhost:3306/shopware";
+  env.MAILER_DSN = lib.mkDefault "smtp://127.0.0.1:1025";
+  env.DATABASE_URL = lib.mkDefault "mysql://shopware:shopware@127.0.0.1:3306/shopware";
 
   # Shopware 6 related scripts
   scripts.build-js.exec = lib.mkDefault "bin/build-js.sh";


### PR DESCRIPTION
As described here: https://developer.shopware.com/docs/guides/installation/devenv#faq