### PR TITLE
Add --active-only flag to theme compile in watch-storefront.sh

### DIFF
--- a/shopware/storefront/6.4/bin/watch-storefront.sh
+++ b/shopware/storefront/6.4/bin/watch-storefront.sh
@@ -24,7 +24,7 @@ export STOREFRONT_ASSETS_PORT
 export STOREFRONT_PROXY_PORT
 
 DATABASE_URL="" "${CWD}"/console feature:dump
-"${CWD}"/console theme:compile
+"${CWD}"/console theme:compile --active-only
 "${CWD}"/console theme:dump
 
 if [[ $(command -v jq) ]]; then


### PR DESCRIPTION
When using watch-storefront.sh it makes sense to only compile the theme for active sales channels, because inactive sales can't be reached so no need to compile them. 