### PR TITLE
feat: update rector

### DIFF
--- a/frosh/code-quality-meta/0.2/manifest.json
+++ b/frosh/code-quality-meta/0.2/manifest.json
@@ -1,0 +1,11 @@
+{
+    "aliases": ["code-quality"],
+    "copy-from-recipe": {
+        "vendor-bin/": "vendor-bin/",
+        "root/": ""
+    },
+    "gitignore": [
+        "phpstan.neon",
+        "/vendor-bin/**/vendor/"
+    ]
+}

--- a/frosh/code-quality-meta/0.2/post-install.txt
+++ b/frosh/code-quality-meta/0.2/post-install.txt
@@ -1,0 +1,24 @@
+  * <fg=blue>Setup</> execute:
+    <comment>composer require --dev bamarni/composer-bin-plugin && jq '.extra += {"bamarni-bin": {"bin-links": false, "forward-command": true}}' composer.json > composer.tmp && mv composer.tmp composer.json && composer install</comment>
+
+  * <fg=blue>Recommended</>
+    The following code snippet shows examples of how to use code quality tools to check and improve the quality of your code.
+    You can customize the plugin paths based on your project's needs.
+    <comment>{
+        "script": {
+            "ecs": "@php vendor-bin/cs-fixer/vendor/bin/ecs check custom/static-plugins custom/plugins",
+            "ecs-fix": "@php vendor-bin/cs-fixer/vendor/bin/ecs check --fix custom/static-plugins custom/plugins",
+            "phpstan": [
+              "@php vendor/frosh/code-quality-meta/phpstan-bootstrap.php",
+              "@php vendor-bin/phpstan/vendor/bin/phpstan analyze custom/static-plugins custom/plugins"
+            ],
+            "rector-dry": "@php vendor-bin/rector/vendor/bin/rector process --config=rector.php --dry-run",
+            "rector": "@php vendor-bin/rector/vendor/bin/rector process --config=rector.php",
+            "commit": [
+                "@phpstan",
+                "@rector",
+                "@ecs-fix",
+                "@php bin/console dal:validate"
+            ]
+        }
+    }</comment>

--- a/frosh/code-quality-meta/0.2/root/ecs.php
+++ b/frosh/code-quality-meta/0.2/root/ecs.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Fixer\CastNotation\ModernizeTypesCastingFixer;
+use PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer;
+use PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer;
+use PhpCsFixer\Fixer\ConstantNotation\NativeConstantInvocationFixer;
+use PhpCsFixer\Fixer\FunctionNotation\FopenFlagsFixer;
+use PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer;
+use PhpCsFixer\Fixer\FunctionNotation\NativeFunctionInvocationFixer;
+use PhpCsFixer\Fixer\FunctionNotation\NullableTypeDeclarationForDefaultNullValueFixer;
+use PhpCsFixer\Fixer\FunctionNotation\SingleLineThrowFixer;
+use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
+use PhpCsFixer\Fixer\LanguageConstruct\ExplicitIndirectVariableFixer;
+use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
+use PhpCsFixer\Fixer\Operator\ConcatSpaceFixer;
+use PhpCsFixer\Fixer\Operator\OperatorLinebreakFixer;
+use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
+use PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocAlignFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocAnnotationWithoutDotFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocIndentFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocLineSpanFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocNoPackageFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocOrderFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocSummaryFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocTrimConsecutiveBlankLineSeparationFixer;
+use PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitConstructFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertInternalTypeFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitMockFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitMockShortWillReturnFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestCaseStaticMethodCallsFixer;
+use PhpCsFixer\Fixer\ReturnNotation\NoUselessReturnFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
+use PhpCsFixer\Fixer\StringNotation\ExplicitStringVariableFixer;
+use PhpCsFixer\Fixer\StringNotation\SingleQuoteFixer;
+use PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer;
+use PhpCsFixer\Fixer\Whitespace\CompactNullableTypehintFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocToCommentFixer;
+use PhpCsFixerCustomFixers\Fixer\MultilinePromotedPropertiesFixer;
+use PhpCsFixerCustomFixers\Fixer\NoImportFromGlobalNamespaceFixer;
+use PhpCsFixerCustomFixers\Fixer\NoSuperfluousConcatenationFixer;
+use PhpCsFixerCustomFixers\Fixer\NoUselessCommentFixer;
+use PhpCsFixerCustomFixers\Fixer\NoUselessParenthesisFixer;
+use PhpCsFixerCustomFixers\Fixer\NoUselessStrlenFixer;
+use PhpCsFixerCustomFixers\Fixer\PhpdocTypesCommaSpacesFixer;
+use PhpCsFixerCustomFixers\Fixer\SingleSpaceAfterStatementFixer;
+use Symplify\CodingStandard\Fixer\ArrayNotation\ArrayListItemNewlineFixer;
+use Symplify\CodingStandard\Fixer\ArrayNotation\ArrayOpenerAndCloserNewlineFixer;
+use Symplify\CodingStandard\Fixer\ArrayNotation\StandaloneLineInMultilineArrayFixer;
+use Symplify\CodingStandard\Fixer\Spacing\StandaloneLineConstructorParamFixer;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff;
+
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->dynamicSets([
+        '@Symfony',
+        '@Symfony:risky',
+        '@PHP81Migration'
+    ]);
+
+    $ecsConfig->sets([
+        SetList::ARRAY,
+        SetList::CONTROL_STRUCTURES,
+        SetList::STRICT,
+        SetList::PSR_12,
+    ]);
+
+    $ecsConfig->rules([
+        ModernizeTypesCastingFixer::class,
+        FopenFlagsFixer::class,
+        NativeConstantInvocationFixer::class,
+        NullableTypeDeclarationForDefaultNullValueFixer::class,
+        VoidReturnFixer::class,
+        OperatorLinebreakFixer::class,
+        PhpdocLineSpanFixer::class,
+        PhpdocOrderFixer::class,
+        PhpUnitConstructFixer::class,
+        PhpUnitDedicateAssertInternalTypeFixer::class,
+        PhpUnitMockFixer::class,
+        PhpUnitMockShortWillReturnFixer::class,
+        PhpUnitTestCaseStaticMethodCallsFixer::class,
+        NoUselessReturnFixer::class,
+        DeclareStrictTypesFixer::class,
+        BlankLineBeforeStatementFixer::class,
+        CompactNullableTypehintFixer::class,
+        NoImportFromGlobalNamespaceFixer::class,
+        NoSuperfluousConcatenationFixer::class,
+        NoUselessCommentFixer::class,
+        SingleSpaceAfterStatementFixer::class,
+        NoUselessParenthesisFixer::class,
+        NoUselessStrlenFixer::class,
+        PhpdocTypesCommaSpacesFixer::class,
+    ]);
+
+    $ecsConfig->ruleWithConfiguration(ClassAttributesSeparationFixer::class, ['elements' => ['property' => 'one', 'method' => 'one']]);
+    $ecsConfig->ruleWithConfiguration(MethodArgumentSpaceFixer::class, ['on_multiline' => 'ensure_fully_multiline']);
+    $ecsConfig->ruleWithConfiguration(NativeFunctionInvocationFixer::class, [
+        'include' => [NativeFunctionInvocationFixer::SET_COMPILER_OPTIMIZED],
+        'scope' => 'namespaced',
+        'strict' => false,
+    ]);
+    $ecsConfig->ruleWithConfiguration(ConcatSpaceFixer::class, ['spacing' => 'one']);
+    $ecsConfig->ruleWithConfiguration(GeneralPhpdocAnnotationRemoveFixer::class, ['annotations' => ['copyright', 'category']]);
+    $ecsConfig->ruleWithConfiguration(NoSuperfluousPhpdocTagsFixer::class, ['allow_unused_params' => true, 'allow_mixed' => true]);
+    $ecsConfig->ruleWithConfiguration(PhpUnitDedicateAssertFixer::class, ['target' => 'newest']);
+    $ecsConfig->ruleWithConfiguration(SingleQuoteFixer::class, ['strings_containing_single_quote_chars' => true]);
+    $ecsConfig->ruleWithConfiguration(MultilinePromotedPropertiesFixer::class, ['minimum_number_of_parameters' => 2]);
+    // workaround for https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/5495
+    $ecsConfig->ruleWithConfiguration(BinaryOperatorSpacesFixer::class, [
+        'operators' => [
+            '|' => null,
+            '&' => null,
+        ],
+    ]);
+
+    $ecsConfig->cacheDirectory($_SERVER['SHOPWARE_TOOL_CACHE_ECS'] ?? 'var/cache/cs_fixer');
+    $ecsConfig->cacheNamespace('platform');
+
+    $ecsConfig->parallel();
+
+    $ecsConfig->skip([
+        ArrayOpenerAndCloserNewlineFixer::class => null,
+        ArrayListItemNewlineFixer::class => null,
+        SingleLineThrowFixer::class => null,
+        SelfAccessorFixer::class => null,
+        ExplicitIndirectVariableFixer::class => null,
+        BlankLineAfterOpeningTagFixer::class => null,
+        PhpdocSummaryFixer::class => null,
+        ExplicitStringVariableFixer::class => null,
+        StandaloneLineInMultilineArrayFixer::class => null,
+        AssignmentInConditionSniff::class => null,
+        PhpdocToCommentFixer::class => null,
+        PhpdocAlignFixer::class => null,
+        PhpdocAnnotationWithoutDotFixer::class => null,
+        '**/node_modules',
+        // would otherwise destroy markdown in the description of a route annotation, since markdown interpreted spaces/indents
+        PhpdocIndentFixer::class => [
+            'src/**/*Controller.php',
+            'src/**/*Route.php',
+        ],
+        // would otherwise remove lines in the description of route annotations
+        PhpdocTrimConsecutiveBlankLineSeparationFixer::class => [
+            'src/**/*Controller.php',
+            'src/**/*Route.php',
+        ],
+        PhpdocNoPackageFixer::class => null,
+    ]);
+};

--- a/frosh/code-quality-meta/0.2/root/phpstan.neon.dist
+++ b/frosh/code-quality-meta/0.2/root/phpstan.neon.dist
@@ -1,0 +1,41 @@
+parameters:
+    level: 8
+    tmpDir: var/cache/phpstan_dev
+    inferPrivatePropertyTypeFromConstructor: true
+    checkMissingIterableValueType: false
+
+    symfony:
+        constantHassers: false
+        containerXmlPath: 'var/cache/phpstan_dev/Shopware_Core_DevOps_StaticAnalyze_StaticAnalyzeKernelPhpstan_devDebugContainer.xml'
+
+    bootstrapFiles:
+        - vendor/frosh/code-quality-meta/phpstan-bootstrap.php
+
+    excludePaths:
+        - **/vendor/*
+rules:
+    # rules from https://github.com/symplify/phpstan-rules
+    - Symplify\PHPStanRules\Rules\Spotter\IfElseToMatchSpotterRule
+    - Symplify\PHPStanRules\Rules\Missing\CheckSprintfMatchingTypesRule
+
+    # domain
+    - Symplify\PHPStanRules\Rules\CheckAttributteArgumentClassExistsRule
+    - Symplify\PHPStanRules\Rules\Enum\RequireUniqueEnumConstantRule
+    - Symplify\PHPStanRules\Rules\ForbiddenParamTypeRemovalRule
+    - Symplify\PHPStanRules\Rules\PreventParentMethodVisibilityOverrideRule
+
+    # paths
+    - Symplify\PHPStanRules\Rules\NoMissingDirPathRule
+    - Symplify\PHPStanRules\Rules\NoArrayAccessOnObjectRule
+
+    # dead-code
+    - Symplify\PHPStanRules\Rules\NoIssetOnObjectRule
+
+    # explicit naming
+    - Symplify\PHPStanRules\Rules\NoParentMethodCallOnNoOverrideProcessRule
+    - Symplify\PHPStanRules\Rules\RequireThisOnParentMethodCallRule
+    - Symplify\PHPStanRules\Rules\RequireThisCallOnLocalMethodRule
+    - Symplify\PHPStanRules\Rules\ForbiddenMultipleClassLikeInOneFileRule
+
+    - Symplify\PHPStanRules\Rules\Complexity\ForbiddenArrayMethodCallRule
+    - Symplify\PHPStanRules\Symfony\Rules\PreventDoubleSetParameterRule

--- a/frosh/code-quality-meta/0.2/root/rector.php
+++ b/frosh/code-quality-meta/0.2/root/rector.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Frosh\Rector\Set\ShopwareSetList;
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\Config\RectorConfig;
+use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
+use Rector\PostRector\Rector\NameImportingPostRector;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+use Rector\Symfony\Twig134\Rector\Return_\SimpleFunctionAndFilterRector;
+use Rector\Symfony\Set\SymfonySetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->symfonyContainerXml(__DIR__ . '/var/cache/phpstan_dev/Shopware_Core_DevOps_StaticAnalyze_StaticAnalyzeKernelPhpstan_devDebugContainer.xml');
+
+    $rectorConfig->paths([
+        __DIR__ . '/custom/static-plugins/*/src',
+        __DIR__ . '/custom/plugins/*/src',
+    ]);
+
+    $rectorConfig->bootstrapFiles([
+        __DIR__ . '/vendor/autoload.php',
+    ]);
+
+    $rectorConfig->rule(InlineConstructorDefaultToPropertyRector::class);
+    $rectorConfig->rule(NameImportingPostRector::class);
+    $rectorConfig->rule(SimpleFunctionAndFilterRector::class);
+
+    $rectorConfig->sets([
+        SetList::CODE_QUALITY,
+        SetList::DEAD_CODE,
+        SymfonySetList::SYMFONY_54,
+        SymfonySetList::SYMFONY_60,
+        SymfonySetList::SYMFONY_61,
+        SymfonySetList::SYMFONY_62,
+        SymfonySetList::SYMFONY_CODE_QUALITY,
+        SymfonySetList::ANNOTATIONS_TO_ATTRIBUTES,
+        LevelSetList::UP_TO_PHP_81,
+        ShopwareSetList::SHOPWARE_6_5_0,
+    ]);
+
+    $rectorConfig->skip([
+        AddLiteralSeparatorToNumberRector::class => [
+            __DIR__ . '/custom/plugins/*/src/Migration',
+            __DIR__ . '/custom/static-plugins/*/src/Migration'
+        ]
+    ]);
+};

--- a/frosh/code-quality-meta/0.2/vendor-bin/cs-fixer/composer.json
+++ b/frosh/code-quality-meta/0.2/vendor-bin/cs-fixer/composer.json
@@ -1,0 +1,6 @@
+{
+    "require-dev": {
+        "symplify/easy-coding-standard": "^11.3",
+        "kubawerlos/php-cs-fixer-custom-fixers": "^3.14"
+    }
+}

--- a/frosh/code-quality-meta/0.2/vendor-bin/phpstan/composer.json
+++ b/frosh/code-quality-meta/0.2/vendor-bin/phpstan/composer.json
@@ -1,0 +1,14 @@
+{
+    "require-dev": {
+        "phpstan/phpstan": "^1.10",
+        "phpstan/extension-installer": "^1.3",
+        "phpstan/phpstan-phpunit": "^1.3",
+        "phpstan/phpstan-symfony": "^1.3",
+        "symplify/phpstan-rules": "11.2.5.72"
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
+    }
+}

--- a/frosh/code-quality-meta/0.2/vendor-bin/rector/composer.json
+++ b/frosh/code-quality-meta/0.2/vendor-bin/rector/composer.json
@@ -1,0 +1,6 @@
+{
+    "require-dev": {
+        "rector/rector": "^0.17.3",
+        "frosh/shopware-rector": "^0.2.2"
+    }
+}


### PR DESCRIPTION
- I removed `SimplifyForeachToArrayFilterRector` from rector rules. See https://github.com/rectorphp/rector-src/commit/9df1445de8c8cb5eed5a85446628226f9b03ed76
- I changed the Namespace for SimpleFunctionAndFilterRector. See https://github.com/rectorphp/rector-symfony/commit/ed7129b58c0a2cef939ba2c4f858ef137da7edfa
- I increased rector to ^0.17.3