### PR TITLE
added missing "export STOREFRONT_ASSETS_PORT" on watch-storefront.sh

### DIFF
--- a/shopware/platform/6.4/bin/watch-storefront.sh
+++ b/shopware/platform/6.4/bin/watch-storefront.sh
@@ -18,9 +18,10 @@ eval "$curenv"
 set +o allexport
 
 export APP_URL
-export PROXY_URL
-export STOREFRONT_PROXY_PORT
 export ESLINT_DISABLE
+export PROXY_URL
+export STOREFRONT_ASSETS_PORT
+export STOREFRONT_PROXY_PORT
 
 DATABASE_URL="" "${CWD}"/console feature:dump
 "${CWD}"/console theme:compile

--- a/shopware/storefront/6.4/bin/watch-storefront.sh
+++ b/shopware/storefront/6.4/bin/watch-storefront.sh
@@ -18,9 +18,10 @@ eval "$curenv"
 set +o allexport
 
 export APP_URL
-export PROXY_URL
-export STOREFRONT_PROXY_PORT
 export ESLINT_DISABLE
+export PROXY_URL
+export STOREFRONT_ASSETS_PORT
+export STOREFRONT_PROXY_PORT
 
 DATABASE_URL="" "${CWD}"/console feature:dump
 "${CWD}"/console theme:compile


### PR DESCRIPTION
Missing `export STOREFRONT_ASSETS_PORT` on `watch-storefront.sh`

It's used later on few places, like `Storefront/Resources/app/storefront/build/proxy-server-hot/index.js`, but because it was not exported, the value is `undefined`.

I also order the exports alphabetically.

Reference: https://github.com/shopware/platform/pull/3287