### PR TITLE
Remove unused use statement

### DIFF
--- a/shopware/core/6.4/bin/ci
+++ b/shopware/core/6.4/bin/ci
@@ -3,7 +3,6 @@
 
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\ComposerPluginLoader;
 use Shopware\Core\HttpKernel;
-use Shopware\Core\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 


### PR DESCRIPTION
With https://github.com/shopware/recipes/commit/671f1a957ed89cf6d940792c4fb10eba469d1eb0 the constant was removed, but the use statement has been left there.