### PR TITLE
Use Fastly-Client-IP

### DIFF
--- a/shopware/fastly-meta/6.4/config/fastly/recv/default.vcl
+++ b/shopware/fastly-meta/6.4/config/fastly/recv/default.vcl
@@ -44,9 +44,9 @@ set req.url = querystring.sort(req.url);
 
 # Make sure that the client ip is forward to the client.
 if (req.http.x-forwarded-for) {
-    set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + client.ip;
+    set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + req.http.Fastly-Client-IP;
 } else {
-    set req.http.X-Forwarded-For = client.ip;
+    set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
 }
 
 # Don't cache Authenticate & Authorization


### PR DESCRIPTION
`client.ip` is always the immediate client of the current server. In Fastly terms, this means that in services that use shielding, the `client.ip` may be another Fastly server, not the 'actual' client. `Fastly-Client-IP` doesn't change when being forwarded from one Fastly server to another so will always represent the value of `client.ip` that was first seen by Fastly.