### PR TITLE
fix typos in bash scripts

### DIFF
--- a/shopware/administration/6.4/bin/build-administration.sh
+++ b/shopware/administration/6.4/bin/build-administration.sh
@@ -31,7 +31,7 @@ fi
 
 BIN_TOOL="${CWD}/console"
 
-if [[ ${CI-""} ]]; then
+if [[ ${CI:-""} ]]; then
     BIN_TOOL="${CWD}/ci"
 
     if [[ ! -x "$BIN_TOOL" ]]; then
@@ -40,7 +40,7 @@ if [[ ${CI-""} ]]; then
 fi
 
 # build admin
-[[ ${SHOPWARE_SKIP_BUNDLE_DUMP-""} ]] || "${BIN_TOOL}" bundle:dump
+[[ ${SHOPWARE_SKIP_BUNDLE_DUMP:-""} ]] || "${BIN_TOOL}" bundle:dump
 "${BIN_TOOL}" feature:dump || true
 
 if [[ $(command -v jq) ]]; then
@@ -56,7 +56,7 @@ if [[ $(command -v jq) ]]; then
 
         skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
 
-        if [[ ${!skippingEnvVarName-""} ]]; then
+        if [[ ${!skippingEnvVarName:-""} ]]; then
             continue
         fi
 
@@ -74,11 +74,11 @@ fi
 (cd "${ADMIN_ROOT}"/Resources/app/administration && npm install --no-audit --prefer-offline)
 
 # Dump entity schema
-if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
+if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP:-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
   mkdir -p "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_
   "${BIN_TOOL}" -e prod framework:schema -s 'entity-schema' "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_/entity-schema.json
   (cd "${ADMIN_ROOT}"/Resources/app/administration && npm run convert-entity-schema)
 fi
 
 (cd "${ADMIN_ROOT}"/Resources/app/administration && npm run build)
-[[ ${SHOPWARE_SKIP_ASSET_COPY-""} ]] ||"${BIN_TOOL}" assets:install
+[[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install

--- a/shopware/administration/6.4/bin/watch-administration.sh
+++ b/shopware/administration/6.4/bin/watch-administration.sh
@@ -24,7 +24,7 @@ export APP_URL
 
 BIN_TOOL="${CWD}/console"
 
-[[ ${SHOPWARE_SKIP_BUNDLE_DUMP-""} ]] || "${BIN_TOOL}" bundle:dump
+[[ ${SHOPWARE_SKIP_BUNDLE_DUMP:-""} ]] || "${BIN_TOOL}" bundle:dump
 "${BIN_TOOL}" feature:dump || true
 
 if [[ $(command -v jq) ]]; then
@@ -40,7 +40,7 @@ if [[ $(command -v jq) ]]; then
 
         skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
 
-        if [[ ${!skippingEnvVarName-""} ]]; then
+        if [[ ${!skippingEnvVarName:-""} ]]; then
             continue
         fi
 
@@ -60,7 +60,7 @@ if [ ! -d vendor/shopware/administration/Resources/app/administration/node_modul
 fi
 
 # Dump entity schema
-if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
+if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP:-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
   mkdir -p "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_
   "${BIN_TOOL}" -e prod framework:schema -s 'entity-schema' "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_/entity-schema.json
   (cd "${ADMIN_ROOT}"/Resources/app/administration && npm run convert-entity-schema)

--- a/shopware/administration/6.6/bin/build-administration.sh
+++ b/shopware/administration/6.6/bin/build-administration.sh
@@ -34,7 +34,7 @@ fi
 
 BIN_TOOL="${CWD}/console"
 
-if [[ ${CI-""} ]]; then
+if [[ ${CI:-""} ]]; then
     BIN_TOOL="${CWD}/ci"
 
     if [[ ! -x "$BIN_TOOL" ]]; then
@@ -43,7 +43,7 @@ if [[ ${CI-""} ]]; then
 fi
 
 # build admin
-[[ ${SHOPWARE_SKIP_BUNDLE_DUMP-""} ]] || "${BIN_TOOL}" bundle:dump
+[[ ${SHOPWARE_SKIP_BUNDLE_DUMP:-""} ]] || "${BIN_TOOL}" bundle:dump
 "${BIN_TOOL}" feature:dump || true
 
 if [[ $(command -v jq) ]]; then
@@ -59,7 +59,7 @@ if [[ $(command -v jq) ]]; then
 
         skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
 
-        if [[ ${!skippingEnvVarName-""} ]]; then
+        if [[ ${!skippingEnvVarName:-""} ]]; then
             continue
         fi
 
@@ -77,11 +77,11 @@ fi
 (cd "${ADMIN_ROOT}"/Resources/app/administration && npm install --prefer-offline --production)
 
 # Dump entity schema
-if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
+if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP:-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
   mkdir -p "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_
   "${BIN_TOOL}" -e prod framework:schema -s 'entity-schema' "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_/entity-schema.json
   (cd "${ADMIN_ROOT}"/Resources/app/administration && npm run convert-entity-schema)
 fi
 
 (cd "${ADMIN_ROOT}"/Resources/app/administration && npm run build)
-[[ ${SHOPWARE_SKIP_ASSET_COPY-""} ]] ||"${BIN_TOOL}" assets:install
+[[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install

--- a/shopware/administration/6.6/bin/watch-administration.sh
+++ b/shopware/administration/6.6/bin/watch-administration.sh
@@ -24,7 +24,7 @@ export APP_URL
 
 BIN_TOOL="${CWD}/console"
 
-[[ ${SHOPWARE_SKIP_BUNDLE_DUMP-""} ]] || "${BIN_TOOL}" bundle:dump
+[[ ${SHOPWARE_SKIP_BUNDLE_DUMP:-""} ]] || "${BIN_TOOL}" bundle:dump
 "${BIN_TOOL}" feature:dump || true
 
 if [[ $(command -v jq) ]]; then
@@ -40,7 +40,7 @@ if [[ $(command -v jq) ]]; then
 
         skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
 
-        if [[ ${!skippingEnvVarName-""} ]]; then
+        if [[ ${!skippingEnvVarName:-""} ]]; then
             continue
         fi
 
@@ -60,7 +60,7 @@ if [ ! -d vendor/shopware/administration/Resources/app/administration/node_modul
 fi
 
 # Dump entity schema
-if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
+if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP:-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
   mkdir -p "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_
   "${BIN_TOOL}" -e prod framework:schema -s 'entity-schema' "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_/entity-schema.json
   (cd "${ADMIN_ROOT}"/Resources/app/administration && npm run convert-entity-schema)

--- a/shopware/platform/6.4/bin/build-administration.sh
+++ b/shopware/platform/6.4/bin/build-administration.sh
@@ -31,7 +31,7 @@ fi
 
 BIN_TOOL="${CWD}/console"
 
-if [[ ${CI-""} ]]; then
+if [[ ${CI:-""} ]]; then
     BIN_TOOL="${CWD}/ci"
 
     if [[ ! -x "$BIN_TOOL" ]]; then
@@ -40,7 +40,7 @@ if [[ ${CI-""} ]]; then
 fi
 
 # build admin
-[[ ${SHOPWARE_SKIP_BUNDLE_DUMP-""} ]] || "${BIN_TOOL}" bundle:dump
+[[ ${SHOPWARE_SKIP_BUNDLE_DUMP:-""} ]] || "${BIN_TOOL}" bundle:dump
 "${BIN_TOOL}" feature:dump || true
 
 if [[ $(command -v jq) ]]; then
@@ -56,7 +56,7 @@ if [[ $(command -v jq) ]]; then
 
         skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
 
-        if [[ ${!skippingEnvVarName-""} ]]; then
+        if [[ ${!skippingEnvVarName:-""} ]]; then
             continue
         fi
 
@@ -74,11 +74,11 @@ fi
 (cd "${ADMIN_ROOT}"/Resources/app/administration && npm install --no-audit --prefer-offline)
 
 # Dump entity schema
-if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
+if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP:-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
   mkdir -p "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_
   "${BIN_TOOL}" -e prod framework:schema -s 'entity-schema' "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_/entity-schema.json
   (cd "${ADMIN_ROOT}"/Resources/app/administration && npm run convert-entity-schema)
 fi
 
 (cd "${ADMIN_ROOT}"/Resources/app/administration && npm run build)
-[[ ${SHOPWARE_SKIP_ASSET_COPY-""} ]] ||"${BIN_TOOL}" assets:install
+[[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install

--- a/shopware/platform/6.4/bin/build-storefront.sh
+++ b/shopware/platform/6.4/bin/build-storefront.sh
@@ -15,7 +15,7 @@ fi
 
 BIN_TOOL="${CWD}/console"
 
-if [[ ${CI-""} ]]; then
+if [[ ${CI:-""} ]]; then
     BIN_TOOL="${CWD}/ci"
 
     if [[ ! -x "$BIN_TOOL" ]]; then
@@ -24,8 +24,8 @@ if [[ ${CI-""} ]]; then
 fi
 
 # build storefront
-[[ ${SHOPWARE_SKIP_BUNDLE_DUMP-""} ]] || "${BIN_TOOL}" bundle:dump
-[[ ${SHOPWARE_SKIP_FEATURE_DUMP-""} ]] || "${BIN_TOOL}" feature:dump
+[[ ${SHOPWARE_SKIP_BUNDLE_DUMP:-""} ]] || "${BIN_TOOL}" bundle:dump
+[[ ${SHOPWARE_SKIP_FEATURE_DUMP:-""} ]] || "${BIN_TOOL}" feature:dump
 
 if [[ $(command -v jq) ]]; then
     OLDPWD=$(pwd)
@@ -40,7 +40,7 @@ if [[ $(command -v jq) ]]; then
 
         skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
 
-        if [[ ${!skippingEnvVarName-""} ]]; then
+        if [[ ${!skippingEnvVarName:-""} ]]; then
             continue
         fi
 
@@ -58,5 +58,5 @@ fi
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --no-audit --prefer-offline
 node "${STOREFRONT_ROOT}"/Resources/app/storefront/copy-to-vendor.js
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run production
-[[ ${SHOPWARE_SKIP_ASSET_COPY-""} ]] ||"${BIN_TOOL}" assets:install
-[[ ${SHOPWARE_SKIP_THEME_COMPILE-""} ]] || "${BIN_TOOL}" theme:compile
+[[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install
+[[ ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]] || "${BIN_TOOL}" theme:compile

--- a/shopware/platform/6.4/bin/watch-administration.sh
+++ b/shopware/platform/6.4/bin/watch-administration.sh
@@ -24,7 +24,7 @@ export APP_URL
 
 BIN_TOOL="${CWD}/console"
 
-[[ ${SHOPWARE_SKIP_BUNDLE_DUMP-""} ]] || "${BIN_TOOL}" bundle:dump
+[[ ${SHOPWARE_SKIP_BUNDLE_DUMP:-""} ]] || "${BIN_TOOL}" bundle:dump
 "${BIN_TOOL}" feature:dump || true
 
 if [[ $(command -v jq) ]]; then
@@ -40,7 +40,7 @@ if [[ $(command -v jq) ]]; then
 
         skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
 
-        if [[ ${!skippingEnvVarName-""} ]]; then
+        if [[ ${!skippingEnvVarName:-""} ]]; then
             continue
         fi
 
@@ -60,7 +60,7 @@ if [ ! -d vendor/shopware/administration/Resources/app/administration/node_modul
 fi
 
 # Dump entity schema
-if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
+if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP:-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
   mkdir -p "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_
   "${BIN_TOOL}" -e prod framework:schema -s 'entity-schema' "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_/entity-schema.json
   (cd "${ADMIN_ROOT}"/Resources/app/administration && npm run convert-entity-schema)

--- a/shopware/platform/6.4/bin/watch-storefront.sh
+++ b/shopware/platform/6.4/bin/watch-storefront.sh
@@ -40,7 +40,7 @@ if [[ $(command -v jq) ]]; then
 
         skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
 
-        if [[ ${!skippingEnvVarName-""} ]]; then
+        if [[ ${!skippingEnvVarName:-""} ]]; then
             continue
         fi
 

--- a/shopware/platform/6.6/bin/build-administration.sh
+++ b/shopware/platform/6.6/bin/build-administration.sh
@@ -34,7 +34,7 @@ fi
 
 BIN_TOOL="${CWD}/console"
 
-if [[ ${CI-""} ]]; then
+if [[ ${CI:-""} ]]; then
     BIN_TOOL="${CWD}/ci"
 
     if [[ ! -x "$BIN_TOOL" ]]; then
@@ -43,7 +43,7 @@ if [[ ${CI-""} ]]; then
 fi
 
 # build admin
-[[ ${SHOPWARE_SKIP_BUNDLE_DUMP-""} ]] || "${BIN_TOOL}" bundle:dump
+[[ ${SHOPWARE_SKIP_BUNDLE_DUMP:-""} ]] || "${BIN_TOOL}" bundle:dump
 "${BIN_TOOL}" feature:dump || true
 
 if [[ $(command -v jq) ]]; then
@@ -59,7 +59,7 @@ if [[ $(command -v jq) ]]; then
 
         skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
 
-        if [[ ${!skippingEnvVarName-""} ]]; then
+        if [[ ${!skippingEnvVarName:-""} ]]; then
             continue
         fi
 
@@ -77,11 +77,11 @@ fi
 (cd "${ADMIN_ROOT}"/Resources/app/administration && npm install --prefer-offline --production)
 
 # Dump entity schema
-if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
+if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP:-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
   mkdir -p "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_
   "${BIN_TOOL}" -e prod framework:schema -s 'entity-schema' "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_/entity-schema.json
   (cd "${ADMIN_ROOT}"/Resources/app/administration && npm run convert-entity-schema)
 fi
 
 (cd "${ADMIN_ROOT}"/Resources/app/administration && npm run build)
-[[ ${SHOPWARE_SKIP_ASSET_COPY-""} ]] ||"${BIN_TOOL}" assets:install
+[[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install

--- a/shopware/platform/6.6/bin/build-storefront.sh
+++ b/shopware/platform/6.6/bin/build-storefront.sh
@@ -18,7 +18,7 @@ fi
 
 BIN_TOOL="${CWD}/console"
 
-if [[ ${CI-""} ]]; then
+if [[ ${CI:-""} ]]; then
     BIN_TOOL="${CWD}/ci"
 
     if [[ ! -x "$BIN_TOOL" ]]; then
@@ -27,8 +27,8 @@ if [[ ${CI-""} ]]; then
 fi
 
 # build storefront
-[[ ${SHOPWARE_SKIP_BUNDLE_DUMP-""} ]] || "${BIN_TOOL}" bundle:dump
-[[ ${SHOPWARE_SKIP_FEATURE_DUMP-""} ]] || "${BIN_TOOL}" feature:dump
+[[ ${SHOPWARE_SKIP_BUNDLE_DUMP:-""} ]] || "${BIN_TOOL}" bundle:dump
+[[ ${SHOPWARE_SKIP_FEATURE_DUMP:-""} ]] || "${BIN_TOOL}" feature:dump
 
 if [[ $(command -v jq) ]]; then
     OLDPWD=$(pwd)
@@ -43,7 +43,7 @@ if [[ $(command -v jq) ]]; then
 
         skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
 
-        if [[ ${!skippingEnvVarName-""} ]]; then
+        if [[ ${!skippingEnvVarName:-""} ]]; then
             continue
         fi
 
@@ -61,5 +61,5 @@ fi
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --prefer-offline --production
 node "${STOREFRONT_ROOT}"/Resources/app/storefront/copy-to-vendor.js
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run production
-[[ ${SHOPWARE_SKIP_ASSET_COPY-""} ]] ||"${BIN_TOOL}" assets:install
-[[ ${SHOPWARE_SKIP_THEME_COMPILE-""} ]] || "${BIN_TOOL}" theme:compile --active-only
+[[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install
+[[ ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]] || "${BIN_TOOL}" theme:compile --active-only

--- a/shopware/platform/6.6/bin/watch-administration.sh
+++ b/shopware/platform/6.6/bin/watch-administration.sh
@@ -24,7 +24,7 @@ export APP_URL
 
 BIN_TOOL="${CWD}/console"
 
-[[ ${SHOPWARE_SKIP_BUNDLE_DUMP-""} ]] || "${BIN_TOOL}" bundle:dump
+[[ ${SHOPWARE_SKIP_BUNDLE_DUMP:-""} ]] || "${BIN_TOOL}" bundle:dump
 "${BIN_TOOL}" feature:dump || true
 
 if [[ $(command -v jq) ]]; then
@@ -40,7 +40,7 @@ if [[ $(command -v jq) ]]; then
 
         skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
 
-        if [[ ${!skippingEnvVarName-""} ]]; then
+        if [[ ${!skippingEnvVarName:-""} ]]; then
             continue
         fi
 
@@ -60,7 +60,7 @@ if [ ! -d vendor/shopware/administration/Resources/app/administration/node_modul
 fi
 
 # Dump entity schema
-if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
+if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP:-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
   mkdir -p "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_
   "${BIN_TOOL}" -e prod framework:schema -s 'entity-schema' "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_/entity-schema.json
   (cd "${ADMIN_ROOT}"/Resources/app/administration && npm run convert-entity-schema)

--- a/shopware/platform/6.6/bin/watch-storefront.sh
+++ b/shopware/platform/6.6/bin/watch-storefront.sh
@@ -53,7 +53,7 @@ if [[ $(command -v jq) ]]; then
 
         skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
 
-        if [[ ${!skippingEnvVarName-""} ]]; then
+        if [[ ${!skippingEnvVarName:-""} ]]; then
             continue
         fi
 

--- a/shopware/storefront/6.4/bin/build-storefront.sh
+++ b/shopware/storefront/6.4/bin/build-storefront.sh
@@ -15,7 +15,7 @@ fi
 
 BIN_TOOL="${CWD}/console"
 
-if [[ ${CI-""} ]]; then
+if [[ ${CI:-""} ]]; then
     BIN_TOOL="${CWD}/ci"
 
     if [[ ! -x "$BIN_TOOL" ]]; then
@@ -24,8 +24,8 @@ if [[ ${CI-""} ]]; then
 fi
 
 # build storefront
-[[ ${SHOPWARE_SKIP_BUNDLE_DUMP-""} ]] || "${BIN_TOOL}" bundle:dump
-[[ ${SHOPWARE_SKIP_FEATURE_DUMP-""} ]] || "${BIN_TOOL}" feature:dump
+[[ ${SHOPWARE_SKIP_BUNDLE_DUMP:-""} ]] || "${BIN_TOOL}" bundle:dump
+[[ ${SHOPWARE_SKIP_FEATURE_DUMP:-""} ]] || "${BIN_TOOL}" feature:dump
 
 if [[ $(command -v jq) ]]; then
     OLDPWD=$(pwd)
@@ -40,7 +40,7 @@ if [[ $(command -v jq) ]]; then
 
         skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
 
-        if [[ ${!skippingEnvVarName-""} ]]; then
+        if [[ ${!skippingEnvVarName:-""} ]]; then
             continue
         fi
 
@@ -58,5 +58,5 @@ fi
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --no-audit --prefer-offline
 node "${STOREFRONT_ROOT}"/Resources/app/storefront/copy-to-vendor.js
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run production
-[[ ${SHOPWARE_SKIP_ASSET_COPY-""} ]] ||"${BIN_TOOL}" assets:install
-[[ ${SHOPWARE_SKIP_THEME_COMPILE-""} ]] || "${BIN_TOOL}" theme:compile
+[[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install
+[[ ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]] || "${BIN_TOOL}" theme:compile

--- a/shopware/storefront/6.4/bin/watch-storefront.sh
+++ b/shopware/storefront/6.4/bin/watch-storefront.sh
@@ -40,7 +40,7 @@ if [[ $(command -v jq) ]]; then
 
         skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
 
-        if [[ ${!skippingEnvVarName-""} ]]; then
+        if [[ ${!skippingEnvVarName:-""} ]]; then
             continue
         fi
 

--- a/shopware/storefront/6.6/bin/build-storefront.sh
+++ b/shopware/storefront/6.6/bin/build-storefront.sh
@@ -18,7 +18,7 @@ fi
 
 BIN_TOOL="${CWD}/console"
 
-if [[ ${CI-""} ]]; then
+if [[ ${CI:-""} ]]; then
     BIN_TOOL="${CWD}/ci"
 
     if [[ ! -x "$BIN_TOOL" ]]; then
@@ -27,8 +27,8 @@ if [[ ${CI-""} ]]; then
 fi
 
 # build storefront
-[[ ${SHOPWARE_SKIP_BUNDLE_DUMP-""} ]] || "${BIN_TOOL}" bundle:dump
-[[ ${SHOPWARE_SKIP_FEATURE_DUMP-""} ]] || "${BIN_TOOL}" feature:dump
+[[ ${SHOPWARE_SKIP_BUNDLE_DUMP:-""} ]] || "${BIN_TOOL}" bundle:dump
+[[ ${SHOPWARE_SKIP_FEATURE_DUMP:-""} ]] || "${BIN_TOOL}" feature:dump
 
 if [[ $(command -v jq) ]]; then
     OLDPWD=$(pwd)
@@ -43,7 +43,7 @@ if [[ $(command -v jq) ]]; then
 
         skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
 
-        if [[ ${!skippingEnvVarName-""} ]]; then
+        if [[ ${!skippingEnvVarName:-""} ]]; then
             continue
         fi
 
@@ -61,5 +61,5 @@ fi
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --prefer-offline --production
 node "${STOREFRONT_ROOT}"/Resources/app/storefront/copy-to-vendor.js
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run production
-[[ ${SHOPWARE_SKIP_ASSET_COPY-""} ]] ||"${BIN_TOOL}" assets:install
-[[ ${SHOPWARE_SKIP_THEME_COMPILE-""} ]] || "${BIN_TOOL}" theme:compile --active-only
+[[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install
+[[ ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]] || "${BIN_TOOL}" theme:compile --active-only

--- a/shopware/storefront/6.6/bin/watch-storefront.sh
+++ b/shopware/storefront/6.6/bin/watch-storefront.sh
@@ -53,7 +53,7 @@ if [[ $(command -v jq) ]]; then
 
         skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
 
-        if [[ ${!skippingEnvVarName-""} ]]; then
+        if [[ ${!skippingEnvVarName:-""} ]]; then
             continue
         fi
 


### PR DESCRIPTION
I've fixed the typos in the bash scripts: without the change, the use of the placeholder variables is not working as intended.

See [shopware!3537](https://github.com/shopware/shopware/pull/3537) for more text.