### PR TITLE
Improve update from 6.5 to 6.6

### DIFF
--- a/shopware/core/6.4/bin/ci
+++ b/shopware/core/6.4/bin/ci
@@ -1,6 +1,7 @@
 #!/usr/bin/env php
 <?php
 
+use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\ComposerPluginLoader;
 use Shopware\Core\HttpKernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -29,8 +30,6 @@ return static function (array &$context) {
     $env = $input->getParameterOption(['--env', '-e'], $context['APP_ENV'] ?? 'prod', true);
     $debug = ($context['APP_DEBUG'] ?? ($env !== 'prod')) && !$input->hasParameterOption('--no-debug', true);
 
-    $pluginLoader = new ComposerPluginLoader($classLoader, null);
-
     if ($input->getFirstArgument() === 'system:install') {
         $context['INSTALL'] = true;
     }
@@ -40,14 +39,24 @@ return static function (array &$context) {
         $_SERVER['DATABASE_URL'] = 'mysql://_placeholder.test';
     }
 
-    $kernel = new HttpKernel($env, $debug, $classLoader);
-    $kernel->setPluginLoader($pluginLoader);
+    if (method_exists(KernelFactory::class, "create")) {
+        $kernel = KernelFactory::create(
+            environment: $env,
+            debug: $debug,
+            classLoader: $classLoader,
+            pluginLoader: new ComposerPluginLoader($classLoader, null)
+        );
+    } else {
+        $kernel = new HttpKernel($env, $debug, $classLoader);
+        $kernel->setPluginLoader(new ComposerPluginLoader($classLoader, null));
+        $kernel = $kernel->getKernel();
+    }
 
-    $application = new Application($kernel->getKernel());
-    $kernel->getKernel()->boot();
+    $application = new Application($kernel);
+    $kernel->boot();
 
     $application->setName('Shopware');
-    $application->setVersion($kernel->getKernel()->getContainer()->getParameter('kernel.shopware_version'));
+    $application->setVersion($kernel->getContainer()->getParameter('kernel.shopware_version'));
 
     return $application;
 };

--- a/shopware/core/6.4/bin/console
+++ b/shopware/core/6.4/bin/console
@@ -1,12 +1,15 @@
 #!/usr/bin/env php
 <?php
 
+use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\DbalKernelPluginLoader;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
 use Shopware\Core\HttpKernel;
 use Shopware\Core\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
+
+$envFile = __DIR__ . '/../.env';
 
 if (!file_exists(__DIR__ . '/../.env') && !file_exists(__DIR__ . '/../.env.dist') && !file_exists(__DIR__ . '/../.env.local.php')) {
     $_SERVER['APP_RUNTIME_OPTIONS']['disable_dotenv'] = true;
@@ -44,14 +47,24 @@ return static function (array &$context) {
         $pluginLoader = new DbalKernelPluginLoader($classLoader, null, \Shopware\Core\Kernel::getConnection());
     }
 
-    $kernel = new HttpKernel($env, $debug, $classLoader);
-    $kernel->setPluginLoader($pluginLoader);
+    if (method_exists(KernelFactory::class, "create")) {
+        $kernel = KernelFactory::create(
+            environment: $env,
+            debug: $debug,
+            classLoader: $classLoader,
+            pluginLoader: $pluginLoader
+        );
+    } else {
+        $kernel = new HttpKernel($env, $debug, $classLoader);
+        $kernel->setPluginLoader($pluginLoader);
+        $kernel = $kernel->getKernel();
+    }
 
-    $application = new Application($kernel->getKernel());
-    $kernel->getKernel()->boot();
+    $application = new Application($kernel);
+    $kernel->boot();
 
     $application->setName('Shopware');
-    $application->setVersion($kernel->getKernel()->getContainer()->getParameter('kernel.shopware_version'));
+    $application->setVersion($kernel->getContainer()->getParameter('kernel.shopware_version'));
 
     return $application;
 };

--- a/shopware/core/6.4/post-install.txt
+++ b/shopware/core/6.4/post-install.txt
@@ -3,14 +3,14 @@
     1. Go to the project directory
     2. Create your code repository with the <comment>git init</comment> command and push it to your favourite Git service
 
-  * <fg=blue>Run</> locally Shopware:
+  * <fg=blue>Run</> Shopware locally:
 
     1. Adjust the <comment>.env</comment> file to your database
     2. Run <comment>./bin/console system:install --basic-setup</comment>
     3. Optional: If you use Symfony CLI start the webserver <comment>symfony server:start -d</comment>
     3. The default credentials for administration are <comment>admin</comment> with password <comment>shopware</comment>
 
-  * <fg=blue>Run</> with Docker Shopware with Symfony CLI:
+  * <fg=blue>Run</> Shopware with Docker & Symfony CLI:
 
     1. Start the docker containers with <comment>docker compose up -d</comment>
     2. Run <comment>symfony console system:install --basic-setup</comment>
@@ -19,3 +19,8 @@
     5. Optional: Open the Mail catcher with <comment>symfony open:local:webmail</comment>
 
   * <fg=blue>Read</> the documentation at <comment>https://developer.shopware.com/</>
+
+  * <fg=yellow>Warning</> if updating from older versions of the production template:
+
+    There might be old `require-dev` dependencies in your `composer.json` file. Please remove them before updating shopware/core to versions >= v6.4.
+    You can do it using this command: <comment>composer config --unset require-dev</>

--- a/shopware/core/6.4/public/index.php
+++ b/shopware/core/6.4/public/index.php
@@ -5,6 +5,7 @@ use Shopware\Core\Framework\Plugin\KernelPluginLoader\ComposerPluginLoader;
 use Shopware\Core\HttpKernel;
 use Shopware\Core\Installer\InstallerKernel;
 use Symfony\Component\HttpFoundation\Request;
+use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\TerminableInterface;
@@ -48,6 +49,20 @@ return function (array $context) {
 
     if (!EnvironmentHelper::getVariable('SHOPWARE_SKIP_WEBINSTALLER', false) && !file_exists(dirname(__DIR__) . '/install.lock')) {
         return new InstallerKernel($appEnv, $debug);
+    }
+
+    if (method_exists(KernelFactory::class, "create")) {
+        $pluginLoader = null;
+        if (EnvironmentHelper::getVariable('COMPOSER_PLUGIN_LOADER', false)) {
+            $pluginLoader = new ComposerPluginLoader($classLoader, null);
+        }
+
+        return KernelFactory::create(
+            environment: $appEnv,
+            debug: $debug,
+            classLoader: $classLoader,
+            pluginLoader: $pluginLoader
+        );
     }
 
     $shopwareHttpKernel = new HttpKernel($appEnv, $debug, $classLoader);

--- a/shopware/core/6.6/post-install.txt
+++ b/shopware/core/6.6/post-install.txt
@@ -3,14 +3,14 @@
     1. Go to the project directory
     2. Create your code repository with the <comment>git init</comment> command and push it to your favourite Git service
 
-  * <fg=blue>Run</> locally Shopware:
+  * <fg=blue>Run</> Shopware locally:
 
     1. Adjust the <comment>.env</comment> file to your database
     2. Run <comment>./bin/console system:install --basic-setup</comment>
     3. Optional: If you use Symfony CLI start the webserver <comment>symfony server:start -d</comment>
     3. The default credentials for administration are <comment>admin</comment> with password <comment>shopware</comment>
 
-  * <fg=blue>Run</> with Docker Shopware with Symfony CLI:
+  * <fg=blue>Run</> Shopware with Docker & Symfony CLI:
 
     1. Start the docker containers with <comment>docker compose up -d</comment>
     2. Run <comment>symfony console system:install --basic-setup</comment>


### PR DESCRIPTION
Change `bin/console`, `bin/ci` and `public/index.php` to be compatible with 6.6. This should improve the update flow a bit