### PR TITLE
feat: Update rector recipe

### DIFF
--- a/frosh/code-quality-meta/0.3/root/rector.php
+++ b/frosh/code-quality-meta/0.3/root/rector.php
@@ -6,7 +6,6 @@ use Frosh\Rector\Set\ShopwareSetList;
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
 use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
-use Rector\PostRector\Rector\NameImportingPostRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 use Rector\Symfony\Twig134\Rector\Return_\SimpleFunctionAndFilterRector;

--- a/frosh/code-quality-meta/0.3/root/rector.php
+++ b/frosh/code-quality-meta/0.3/root/rector.php
@@ -25,8 +25,6 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->rule(InlineConstructorDefaultToPropertyRector::class);
-    $rectorConfig->rule(NameImportingPostRector::class);
-
     $rectorConfig->rule(SimpleFunctionAndFilterRector::class);
 
     $rectorConfig->sets([
@@ -37,10 +35,12 @@ return static function (RectorConfig $rectorConfig): void {
         SymfonySetList::SYMFONY_61,
         SymfonySetList::SYMFONY_62,
         SymfonySetList::SYMFONY_63,
+        SymfonySetList::SYMFONY_64,
         SymfonySetList::SYMFONY_CODE_QUALITY,
         SymfonySetList::ANNOTATIONS_TO_ATTRIBUTES,
         LevelSetList::UP_TO_PHP_81,
         LevelSetList::UP_TO_PHP_82,
+        LevelSetList::UP_TO_PHP_83,
         ShopwareSetList::SHOPWARE_6_5_0,
         ShopwareSetList::SHOPWARE_6_6_0,
     ]);


### PR DESCRIPTION
add Symfony 6.4 setlist, php 8.3 setlist, remove NameImportingPostRector since rector::rule method expects a RectorInterface