### PR TITLE
Refactor build scripts

### DIFF
--- a/shopware/administration/6.6/bin/build-administration.sh
+++ b/shopware/administration/6.6/bin/build-administration.sh
@@ -34,10 +34,10 @@ get_bin_tool
 [[ ${SHOPWARE_SKIP_FEATURE_DUMP:-""} ]] || "${BIN_TOOL}" feature:dump
 
 # Install administration npm dependencies for extensions
-install_extensions_npm_dependencies "administration" "--no-audit --prefer-offline"
+install_extensions_npm_dependencies "administration"
 
 # Install npm dependencies for administration in production mode
-npm --prefix "${ADMIN_ROOT}/Resources/app/administration" install --prefer-offline --production
+npm --prefix "${ADMIN_ROOT}/Resources/app/administration" install --production
 
 # Dump entity schema
 dump_entity_schema

--- a/shopware/administration/6.6/bin/build-administration.sh
+++ b/shopware/administration/6.6/bin/build-administration.sh
@@ -1,87 +1,54 @@
 #!/usr/bin/env bash
 
-CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+set -euo pipefail
 
+# Set project root directory
+CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 export ENV_FILE=${ENV_FILE:-"${PROJECT_ROOT}/.env"}
-export NPM_CONFIG_FUND=false
-export NPM_CONFIG_AUDIT=false
-export NPM_CONFIG_UPDATE_NOTIFIER=false
 
-# shellcheck source=functions.sh
+# Source functions
 source "${PROJECT_ROOT}/bin/functions.sh"
 
-curenv=$(declare -p -x)
-
+# Load environment variables from .env file
 load_dotenv "$ENV_FILE"
+
+# Load current environment variables
+curenv=$(declare -p -x)
 
 # Restore environment variables set globally
 set -o allexport
 eval "$curenv"
 set +o allexport
 
-set -euo pipefail
+# Set npm configuration
+export NPM_CONFIG_FUND=false
+export NPM_CONFIG_AUDIT=false
+export NPM_CONFIG_UPDATE_NOTIFIER=false
 
+# Puppeteer and admin configurations
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 export DISABLE_ADMIN_COMPILATION_TYPECHECK=true
-export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
+export ADMIN_ROOT="${ADMIN_ROOT:-"${PROJECT_ROOT}/vendor/shopware/administration"}"
 
-if [[ -e "${PROJECT_ROOT}/vendor/shopware/platform" ]]; then
-    ADMIN_ROOT="${ADMIN_ROOT:-"${PROJECT_ROOT}/vendor/shopware/platform/src/Administration"}"
-else
-    ADMIN_ROOT="${ADMIN_ROOT:-"${PROJECT_ROOT}/vendor/shopware/administration"}"
-fi
+# Ensure BIN_TOOL is set and executable
+get_bin_tool
 
-BIN_TOOL="${CWD}/console"
-
-if [[ ${CI:-""} ]]; then
-    BIN_TOOL="${CWD}/ci"
-
-    if [[ ! -x "$BIN_TOOL" ]]; then
-        chmod +x "$BIN_TOOL"
-    fi
-fi
-
-# build admin
+# Dump bundles and features if not skipped
 [[ ${SHOPWARE_SKIP_BUNDLE_DUMP:-""} ]] || "${BIN_TOOL}" bundle:dump
-"${BIN_TOOL}" feature:dump || true
+[[ ${SHOPWARE_SKIP_FEATURE_DUMP:-""} ]] || "${BIN_TOOL}" feature:dump
 
-if [[ $(command -v jq) ]]; then
-    OLDPWD=$(pwd)
-    cd "$PROJECT_ROOT" || exit
+# Install administration npm dependencies for extensions
+install_extensions_npm_dependencies "administration" "--no-audit --prefer-offline"
 
-    jq -c '.[]' "var/plugins.json" | while read -r config; do
-        srcPath=$(echo "$config" | jq -r '(.basePath + .administration.path)')
-
-        # the package.json files are always one upper
-        path=$(dirname "$srcPath")
-        name=$(echo "$config" | jq -r '.technicalName' )
-
-        skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
-
-        if [[ ${!skippingEnvVarName:-""} ]]; then
-            continue
-        fi
-
-        if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "administration" ]]; then
-            echo "=> Installing npm dependencies for ${name}"
-
-            npm install --prefix "$path" --no-audit --prefer-offline
-        fi
-    done
-    cd "$OLDPWD" || exit
-else
-    echo "Cannot check extensions for required npm installations as jq is not installed"
-fi
-
-(cd "${ADMIN_ROOT}"/Resources/app/administration && npm install --prefer-offline --production)
+# Install npm dependencies for administration in production mode
+npm --prefix "${ADMIN_ROOT}/Resources/app/administration" install --prefer-offline --production
 
 # Dump entity schema
-if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP:-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
-  mkdir -p "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_
-  "${BIN_TOOL}" -e prod framework:schema -s 'entity-schema' "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_/entity-schema.json
-  (cd "${ADMIN_ROOT}"/Resources/app/administration && npm run convert-entity-schema)
-fi
+dump_entity_schema
 
-(cd "${ADMIN_ROOT}"/Resources/app/administration && npm run build)
-[[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install
+# Build administration
+npm --prefix "${ADMIN_ROOT}/Resources/app/administration" run build
+
+# Install assets if not skipped
+[[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] || "${BIN_TOOL}" assets:install

--- a/shopware/administration/6.6/bin/build-administration.sh
+++ b/shopware/administration/6.6/bin/build-administration.sh
@@ -21,11 +21,6 @@ set -o allexport
 eval "$curenv"
 set +o allexport
 
-# Set npm configuration
-export NPM_CONFIG_FUND=false
-export NPM_CONFIG_AUDIT=false
-export NPM_CONFIG_UPDATE_NOTIFIER=false
-
 # Puppeteer and admin configurations
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 export DISABLE_ADMIN_COMPILATION_TYPECHECK=true

--- a/shopware/administration/6.6/bin/watch-administration.sh
+++ b/shopware/administration/6.6/bin/watch-administration.sh
@@ -21,11 +21,6 @@ set -o allexport
 eval "$curenv"
 set +o allexport
 
-# Set npm configuration
-export NPM_CONFIG_FUND=false
-export NPM_CONFIG_AUDIT=false
-export NPM_CONFIG_UPDATE_NOTIFIER=false
-
 # Set default values for environment variables
 export APP_URL
 export APP_URL=${BACKEND_URL:-${APP_URL}}

--- a/shopware/administration/6.6/bin/watch-administration.sh
+++ b/shopware/administration/6.6/bin/watch-administration.sh
@@ -23,7 +23,6 @@ set +o allexport
 
 # Set default values for environment variables
 export APP_URL
-export APP_URL=${BACKEND_URL:-${APP_URL}}
 export ESLINT_DISABLE
 export HOST=${HOST:-"localhost"}
 export PORT

--- a/shopware/administration/6.6/bin/watch-administration.sh
+++ b/shopware/administration/6.6/bin/watch-administration.sh
@@ -1,69 +1,54 @@
 #!/usr/bin/env bash
 
-CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+set -euo pipefail
 
+# Set project root directory
+CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 export ENV_FILE=${ENV_FILE:-"${PROJECT_ROOT}/.env"}
 
-# shellcheck source=functions.sh
+# Source functions
 source "${PROJECT_ROOT}/bin/functions.sh"
 
-curenv=$(declare -p -x)
-
+# Load environment variables from .env file
 load_dotenv "$ENV_FILE"
+
+# Load current environment variables
+curenv=$(declare -p -x)
 
 # Restore environment variables set globally
 set -o allexport
 eval "$curenv"
 set +o allexport
 
-export HOST=${HOST:-"localhost"}
-export ESLINT_DISABLE
-export PORT
+# Set npm configuration
+export NPM_CONFIG_FUND=false
+export NPM_CONFIG_AUDIT=false
+export NPM_CONFIG_UPDATE_NOTIFIER=false
+
+# Set default values for environment variables
 export APP_URL
+export APP_URL=${BACKEND_URL:-${APP_URL}}
+export ESLINT_DISABLE
+export HOST=${HOST:-"localhost"}
+export PORT
+export ADMIN_ROOT="${ADMIN_ROOT:-"${PROJECT_ROOT}/vendor/shopware/administration"}"
 
-BIN_TOOL="${CWD}/console"
+# Ensure BIN_TOOL is set and executable
+get_bin_tool
 
+# Dump bundles and features if not skipped
 [[ ${SHOPWARE_SKIP_BUNDLE_DUMP:-""} ]] || "${BIN_TOOL}" bundle:dump
-"${BIN_TOOL}" feature:dump || true
+[[ ${SHOPWARE_SKIP_FEATURE_DUMP:-""} ]] || "${BIN_TOOL}" feature:dump
 
-if [[ $(command -v jq) ]]; then
-    OLDPWD=$(pwd)
-    cd "$PROJECT_ROOT" || exit
+# Install webpack-dev-server if not present
+[[ ! -d "${ADMIN_ROOT}"/Resources/app/administration/node_modules/webpack-dev-server ]] && npm --prefix "${ADMIN_ROOT}"/Resources/app/administration install || true
 
-    jq -c '.[]' "var/plugins.json" | while read -r config; do
-        srcPath=$(echo "$config" | jq -r '(.basePath + .administration.path)')
-
-        # the package.json files are always one upper
-        path=$(dirname "$srcPath")
-        name=$(echo "$config" | jq -r '.technicalName' )
-
-        skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
-
-        if [[ ${!skippingEnvVarName:-""} ]]; then
-            continue
-        fi
-
-        if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "administration" ]]; then
-            echo "=> Installing npm dependencies for ${name}"
-
-            npm install --prefix "$path"
-        fi
-    done
-    cd "$OLDPWD" || exit
-else
-    echo "Cannot check extensions for required npm installations as jq is not installed"
-fi
-
-if [ ! -d vendor/shopware/administration/Resources/app/administration/node_modules/webpack-dev-server ]; then
-    npm install --prefix vendor/shopware/administration/Resources/app/administration/
-fi
+# Install administration npm dependencies for extensions
+install_extensions_npm_dependencies "administration"
 
 # Dump entity schema
-if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP:-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then
-  mkdir -p "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_
-  "${BIN_TOOL}" -e prod framework:schema -s 'entity-schema' "${ADMIN_ROOT}"/Resources/app/administration/test/_mocks_/entity-schema.json
-  (cd "${ADMIN_ROOT}"/Resources/app/administration && npm run convert-entity-schema)
-fi
+dump_entity_schema
 
-npm run --prefix vendor/shopware/administration/Resources/app/administration/ dev
+# Build administration in development mode
+npm --prefix "${ADMIN_ROOT}/Resources/app/administration" run dev

--- a/shopware/core/6.6/bin/functions.sh
+++ b/shopware/core/6.6/bin/functions.sh
@@ -8,7 +8,7 @@ load_dotenv() {
     fi
 
     CURRENT_ENV=${APP_ENV:-"dev"}
-    env_file="$1"
+    local env_file="$1"
 
     # If we have an actual .env file load it
     if [[ -e "$env_file" ]]; then
@@ -36,4 +36,82 @@ load_dotenv() {
         # shellcheck source=/dev/null
         source "$env_file.$CURRENT_ENV.local"
     fi
+}
+
+get_bin_tool() {
+    local bin_tool_path="${CWD}/console"
+
+    if [[ -n ${CI:-} ]]; then
+        bin_tool_path="${CWD}/ci"
+
+        if [[ ! -x "$bin_tool_path" ]]; then
+            chmod +x "$bin_tool_path"
+        fi
+    fi
+
+    BIN_TOOL="$bin_tool_path"
+}
+
+dump_entity_schema() {
+    # Check if entity schema dump should be skipped or the file exists
+    if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP:-}" ]] && \
+       [[ -f "${ADMIN_ROOT}/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts" ]]; then
+
+        local mocks_dir="${ADMIN_ROOT}/Resources/app/administration/test/_mocks_"
+
+        # Ensure mocks directory exists
+        mkdir -p "$mocks_dir"
+
+        # Generate entity schema JSON
+        "${BIN_TOOL}" -e prod framework:schema -s 'entity-schema' "${mocks_dir}/entity-schema.json"
+
+        # Convert entity schema JSON
+        npm --prefix "${ADMIN_ROOT}/Resources/app/administration" run convert-entity-schema
+    fi
+}
+
+install_extensions_npm_dependencies() {
+    local component_name="$1"
+    local npm_args=${2:-""}
+
+    if [[ $(command -v jq) ]]; then
+        OLDPWD=$(pwd)
+        cd "$PROJECT_ROOT" || exit
+
+        jq -c '.[]' "var/plugins.json" | while read -r config; do
+            srcPath=$(echo "$config" | jq -r "(.basePath + .${component_name}.path)")
+
+            # the package.json files are always one upper
+            path=$(dirname "$srcPath")
+            name=$(echo "$config" | jq -r '.technicalName' )
+
+            skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
+
+            if [[ ${!skippingEnvVarName:-""} ]]; then
+                continue
+            fi
+
+            if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "$component_name" ]]; then
+                echo "=> Installing npm dependencies for ${name}"
+
+                npm --prefix "$path" install $npm_args
+            fi
+        done
+        cd "$OLDPWD" || exit
+    else
+        echo "Cannot check extensions for required npm installations as jq is not installed"
+    fi
+}
+
+install_and_build_storefront() {
+    local storefront_app_dir="${STOREFRONT_ROOT}/Resources/app/storefront"
+
+    # Install npm dependencies for storefront
+    npm --prefix "$storefront_app_dir" install --prefer-offline --production
+
+    # Copy to vendor
+    node "$storefront_app_dir/copy-to-vendor.js"
+
+    # Run production build
+    npm --prefix "$storefront_app_dir" run production
 }

--- a/shopware/core/6.6/root/.npmrc
+++ b/shopware/core/6.6/root/.npmrc
@@ -1,0 +1,6 @@
+fund=false
+audit=false
+update-notifier=false
+prefer-offline=true
+progress=false
+loglevel=silent

--- a/shopware/storefront/6.6/bin/build-storefront.sh
+++ b/shopware/storefront/6.6/bin/build-storefront.sh
@@ -9,11 +9,6 @@ export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 # Source functions
 source "${PROJECT_ROOT}/bin/functions.sh"
 
-# Set npm configuration
-export NPM_CONFIG_FUND=false
-export NPM_CONFIG_AUDIT=false
-export NPM_CONFIG_UPDATE_NOTIFIER=false
-
 # Puppeteer and storefront configurations
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 export STOREFRONT_ROOT="${STOREFRONT_ROOT:-"${PROJECT_ROOT}/vendor/shopware/storefront"}"

--- a/shopware/storefront/6.6/bin/build-storefront.sh
+++ b/shopware/storefront/6.6/bin/build-storefront.sh
@@ -1,69 +1,43 @@
 #!/usr/bin/env bash
 
-CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
-
 set -euo pipefail
 
-export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+# Set project root directory
+CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
+
+# Source functions
+source "${PROJECT_ROOT}/bin/functions.sh"
+
+# Set npm configuration
 export NPM_CONFIG_FUND=false
 export NPM_CONFIG_AUDIT=false
 export NPM_CONFIG_UPDATE_NOTIFIER=false
 
-if [[ -e "${PROJECT_ROOT}/vendor/shopware/platform" ]]; then
-    STOREFRONT_ROOT="${STOREFRONT_ROOT:-"${PROJECT_ROOT}/vendor/shopware/platform/src/Storefront"}"
-else
-    STOREFRONT_ROOT="${STOREFRONT_ROOT:-"${PROJECT_ROOT}/vendor/shopware/storefront"}"
-fi
+# Puppeteer and storefront configurations
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+export STOREFRONT_ROOT="${STOREFRONT_ROOT:-"${PROJECT_ROOT}/vendor/shopware/storefront"}"
 
-BIN_TOOL="${CWD}/console"
+# Ensure BIN_TOOL is set and executable
+get_bin_tool
 
-if [[ ${CI:-""} ]]; then
-    BIN_TOOL="${CWD}/ci"
-
-    if [[ ! -x "$BIN_TOOL" ]]; then
-        chmod +x "$BIN_TOOL"
-    fi
-fi
-
-# build storefront
+# Dump bundles and features if not skipped
 [[ ${SHOPWARE_SKIP_BUNDLE_DUMP:-""} ]] || "${BIN_TOOL}" bundle:dump
 [[ ${SHOPWARE_SKIP_FEATURE_DUMP:-""} ]] || "${BIN_TOOL}" feature:dump
 
-if [[ $(command -v jq) ]]; then
-    OLDPWD=$(pwd)
-    cd "$PROJECT_ROOT" || exit
+# Install storefront npm dependencies for extensions
+install_extensions_npm_dependencies "storefront" "--prefer-offline"
 
-    jq -c '.[]' "var/plugins.json" | while read -r config; do
-        srcPath=$(echo "$config" | jq -r '(.basePath + .storefront.path)')
+# Install and build storefront
+install_and_build_storefront
 
-        # the package.json files are always one upper
-        path=$(dirname "$srcPath")
-        name=$(echo "$config" | jq -r '.technicalName' )
-
-        skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
-
-        if [[ ${!skippingEnvVarName:-""} ]]; then
-            continue
-        fi
-
-        if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "storefront" ]]; then
-            echo "=> Installing npm dependencies for ${name}"
-
-            npm install --prefix "$path" --prefer-offline
-        fi
-    done
-    cd "$OLDPWD" || exit
-else
-    echo "Cannot check extensions for required npm installations as jq is not installed"
-fi
-
-npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --prefer-offline --production
-node "${STOREFRONT_ROOT}"/Resources/app/storefront/copy-to-vendor.js
-npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run production
+# Install assets if not skipped
 [[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install
+
+# Compile theme if not skipped
 [[ ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]] || "${BIN_TOOL}" theme:compile --active-only
 
+# Clear cache if not instructed otherwise
 if ! [ "${1:-default}" = "--keep-cache" ]; then
     "${BIN_TOOL}" cache:clear
 fi

--- a/shopware/storefront/6.6/bin/build-storefront.sh
+++ b/shopware/storefront/6.6/bin/build-storefront.sh
@@ -21,7 +21,7 @@ get_bin_tool
 [[ ${SHOPWARE_SKIP_FEATURE_DUMP:-""} ]] || "${BIN_TOOL}" feature:dump
 
 # Install storefront npm dependencies for extensions
-install_extensions_npm_dependencies "storefront" "--prefer-offline"
+install_extensions_npm_dependencies "storefront"
 
 # Install and build storefront
 install_and_build_storefront

--- a/shopware/storefront/6.6/bin/watch-storefront.sh
+++ b/shopware/storefront/6.6/bin/watch-storefront.sh
@@ -1,71 +1,52 @@
 #!/usr/bin/env bash
 
-CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+set -euo pipefail
 
+# Set project root directory
+CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 export ENV_FILE=${ENV_FILE:-"${PROJECT_ROOT}/.env"}
-export NPM_CONFIG_FUND=false
-export NPM_CONFIG_AUDIT=false
-export NPM_CONFIG_UPDATE_NOTIFIER=false
 
-# shellcheck source=functions.sh
+# Source functions
 source "${PROJECT_ROOT}/bin/functions.sh"
 
-curenv=$(declare -p -x)
-
+# Load environment variables from .env file
 load_dotenv "$ENV_FILE"
+
+# Load current environment variables
+curenv=$(declare -p -x)
 
 # Restore environment variables set globally
 set -o allexport
 eval "$curenv"
 set +o allexport
 
+# Set npm configuration
+export NPM_CONFIG_FUND=false
+export NPM_CONFIG_AUDIT=false
+export NPM_CONFIG_UPDATE_NOTIFIER=false
+
+# Set default values for environment variables
 export APP_URL
+export APP_URL=${BACKEND_URL:-${APP_URL}}
 export ESLINT_DISABLE
 export PROXY_URL
 export STOREFRONT_ASSETS_PORT
 export STOREFRONT_PROXY_PORT
+export STOREFRONT_ROOT="${STOREFRONT_ROOT:-"${PROJECT_ROOT}/vendor/shopware/storefront"}"
 
-if [[ -e "${PROJECT_ROOT}/vendor/shopware/platform" ]]; then
-    STOREFRONT_ROOT="${STOREFRONT_ROOT:-"${PROJECT_ROOT}/vendor/shopware/platform/src/Storefront"}"
-else
-    STOREFRONT_ROOT="${STOREFRONT_ROOT:-"${PROJECT_ROOT}/vendor/shopware/storefront"}"
-fi
+# Ensure BIN_TOOL is set and executable
+get_bin_tool
+# Dump features and compile theme if not skipped
+[[ ${SHOPWARE_SKIP_FEATURE_DUMP:-""} ]] || "${BIN_TOOL}" feature:dump
+[[ ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]] || "${BIN_TOOL}" theme:compile --active-only
+"${BIN_TOOL}" theme:dump
 
-if [[ ! -d "${STOREFRONT_ROOT}"/Resources/app/storefront/node_modules/webpack-dev-server ]]; then
-    npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --prefer-offline
-fi
+# Install webpack-dev-server if not present
+[[ ! -d "${STOREFRONT_ROOT}"/Resources/app/storefront/node_modules/webpack-dev-server ]] && npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --prefer-offline || true
 
-DATABASE_URL="" "${CWD}"/console feature:dump
-"${CWD}"/console theme:compile --active-only
-"${CWD}"/console theme:dump
+# Install extensions npm dependencies
+install_extensions_npm_dependencies "storefront"
 
-if [[ $(command -v jq) ]]; then
-    OLDPWD=$(pwd)
-    cd "$PROJECT_ROOT" || exit
-
-    jq -c '.[]' "var/plugins.json" | while read -r config; do
-        srcPath=$(echo "$config" | jq -r '(.basePath + .storefront.path)')
-
-        # the package.json files are always one upper
-        path=$(dirname "$srcPath")
-        name=$(echo "$config" | jq -r '.technicalName' )
-
-        skippingEnvVarName="SKIP_$(echo "$name" | sed -e 's/\([a-z]\)/\U\1/g' -e 's/-/_/g')"
-
-        if [[ ${!skippingEnvVarName:-""} ]]; then
-            continue
-        fi
-
-        if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "storefront" ]]; then
-            echo "=> Installing npm dependencies for ${name}"
-
-            npm install --prefix "$path"
-        fi
-    done
-    cd "$OLDPWD" || exit
-else
-    echo "Cannot check extensions for required npm installations as jq is not installed"
-fi
-
+# Run hot-proxy script
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run-script hot-proxy

--- a/shopware/storefront/6.6/bin/watch-storefront.sh
+++ b/shopware/storefront/6.6/bin/watch-storefront.sh
@@ -32,13 +32,14 @@ export STOREFRONT_ROOT="${STOREFRONT_ROOT:-"${PROJECT_ROOT}/vendor/shopware/stor
 
 # Ensure BIN_TOOL is set and executable
 get_bin_tool
+
 # Dump features and compile theme if not skipped
 [[ ${SHOPWARE_SKIP_FEATURE_DUMP:-""} ]] || "${BIN_TOOL}" feature:dump
 [[ ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]] || "${BIN_TOOL}" theme:compile --active-only
 "${BIN_TOOL}" theme:dump
 
 # Install webpack-dev-server if not present
-[[ ! -d "${STOREFRONT_ROOT}"/Resources/app/storefront/node_modules/webpack-dev-server ]] && npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --prefer-offline || true
+[[ ! -d "${STOREFRONT_ROOT}"/Resources/app/storefront/node_modules/webpack-dev-server ]] && npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install || true
 
 # Install extensions npm dependencies
 install_extensions_npm_dependencies "storefront"

--- a/shopware/storefront/6.6/bin/watch-storefront.sh
+++ b/shopware/storefront/6.6/bin/watch-storefront.sh
@@ -23,7 +23,6 @@ set +o allexport
 
 # Set default values for environment variables
 export APP_URL
-export APP_URL=${BACKEND_URL:-${APP_URL}}
 export ESLINT_DISABLE
 export PROXY_URL
 export STOREFRONT_ASSETS_PORT

--- a/shopware/storefront/6.6/bin/watch-storefront.sh
+++ b/shopware/storefront/6.6/bin/watch-storefront.sh
@@ -21,11 +21,6 @@ set -o allexport
 eval "$curenv"
 set +o allexport
 
-# Set npm configuration
-export NPM_CONFIG_FUND=false
-export NPM_CONFIG_AUDIT=false
-export NPM_CONFIG_UPDATE_NOTIFIER=false
-
 # Set default values for environment variables
 export APP_URL
 export APP_URL=${BACKEND_URL:-${APP_URL}}


### PR DESCRIPTION
The existing build and watcher scripts lack consistency.

The refactored storefront and administration build scripts and watchers are more clear and consistent now, they are sharing the same flow and functionalities.
Npm configurations are extracted outside bash scripts into .npmrc project file.