### PR TITLE
Add bundle dump to storefront watch script

### DIFF
--- a/shopware/storefront/6.6/bin/watch-storefront.sh
+++ b/shopware/storefront/6.6/bin/watch-storefront.sh
@@ -36,6 +36,7 @@ if [[ ! -d "${STOREFRONT_ROOT}"/Resources/app/storefront/node_modules/webpack-de
     npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --prefer-offline
 fi
 
+DATABASE_URL="" "${CWD}"/console bundle:dump
 DATABASE_URL="" "${CWD}"/console feature:dump
 "${CWD}"/console theme:compile --active-only
 "${CWD}"/console theme:dump


### PR DESCRIPTION
After creating a fresh setup, the first attempt to run the `watch-storefront.sh` script fails because the `var/plugins.json` file is still missing. 

```
> sw-next-storefront@1.0.0 hot-proxy
> NODE_ENV=development MODE=hot node ./build/start-hot-reload.js

/Users/tobiasberge/www/flex/vendor/shopware/storefront/Resources/app/storefront/webpack.config.js:58
        throw new Error(`The file ${pluginFile} could not be found. Try bin/console bundle:dump to create this file.`);
              ^
```

You have to manually run `bin/console bundle:dump` to get it to run.

Adding `bundle:dump` to the script, similar to the shopware composer script (`composer watch:storefront`) so it works right away.

Also, when installing or removing extensions it is considered after re-starting the watcher.



