### PR TITLE
Replace deprecated phpstan config option

### DIFF
--- a/frosh/code-quality-meta/0.3/root/phpstan.neon.dist
+++ b/frosh/code-quality-meta/0.3/root/phpstan.neon.dist
@@ -2,7 +2,9 @@ parameters:
     level: 8
     tmpDir: var/cache/phpstan_dev
     inferPrivatePropertyTypeFromConstructor: true
-    checkMissingIterableValueType: false
+    ignoreErrors:
+    		-
+    			identifier: missingType.iterableValue
 
     symfony:
         constantHassers: false

--- a/frosh/code-quality-meta/0.3/root/phpstan.neon.dist
+++ b/frosh/code-quality-meta/0.3/root/phpstan.neon.dist
@@ -3,8 +3,8 @@ parameters:
     tmpDir: var/cache/phpstan_dev
     inferPrivatePropertyTypeFromConstructor: true
     ignoreErrors:
-    		-
-    			identifier: missingType.iterableValue
+        -
+            identifier: missingType.iterableValue
 
     symfony:
         constantHassers: false


### PR DESCRIPTION
Phpstan suggests replacing deprecated config option `checkMissingIterableValueType` with `missingType.iterableValue ` if we want to continue ignoring missing typehints from arrays.
https://phpstan.org/error-identifiers/missingType.iterableValue