### PR TITLE
fix: incompatible use of dynamic environment variable

### DIFF
--- a/shopware/k8s-meta/1.0/config/packages/operator.yaml
+++ b/shopware/k8s-meta/1.0/config/packages/operator.yaml
@@ -8,7 +8,8 @@ parameters:
     env(K8S_FILESYSTEM_ENDPOINT): ""
     # does not work yet, we need a factory or compiler pass for this
     # env(K8S_CACHE_TYPE): "cache.adapter.redis_tag_aware"
-    env(K8S_CACHE_URL): "redis://localhost:6379"
+    env(K8S_REDIS_HOST): "localhost"
+    env(K8S_REDIS_PORT): "6379"
 shopware:
     api:
         jwt_key:
@@ -62,4 +63,4 @@ elasticsearch:
 framework:
     cache:
         app: cache.adapter.redis_tag_aware
-        default_redis_provider: '%env(K8S_CACHE_URL)%'
+        default_redis_provider: 'redis://%env(K8S_REDIS_HOST)%:%env(K8S_REDIS_PORT)%'


### PR DESCRIPTION
We're currently getting an error like this when trying to `composer update` with this recipe:
```
Symfony\\Component\\DependencyInjection\\Exception\\EnvParameterException: Incompatible use of dynamic environment variables \"K8S_CACHE_TYPE\"
```

I've updated the config according to [this hint](https://github.com/symfony/symfony/issues/20850#issuecomment-266047338) by the Symfony team.