### PR TITLE
temp folder required by SwagMigrationAssistant

### DIFF
--- a/shopware/paas-meta/6.6/.platform/applications.yaml
+++ b/shopware/paas-meta/6.6/.platform/applications.yaml
@@ -237,6 +237,10 @@
         "/localCache":
             source: local
             source_path: "localCache"
+        "/_temp":
+            source: service
+            service: fileshare
+            source_path: "temp-SwagMigrationAssistant"
 
     # The configuration of app when it is exposed to the web.
     web:


### PR DESCRIPTION
SwagMigrationAssistant requires a `_temp` folder.
This is currently not configurable. An issue has been opened: https://issues.shopware.com/issues/MIG-1038.
In the meantime, we added this `_temp` folder as a shared mount.