### PR TITLE
remove theme-config from gitignore

### DIFF
--- a/shopware/paas-meta/6.6/manifest.json
+++ b/shopware/paas-meta/6.6/manifest.json
@@ -12,8 +12,5 @@
         "default_redis_host": "rediscache.internal",
         "default_redis_port": "6379",
         "env(CACHE_URL)": "redis://localhost"
-    },
-    "gitignore": [
-        "!/files/theme-config"
-    ]
+    }
 }


### PR DESCRIPTION
As the theme:compile is not executed without database during the build step anymore, the theme-config can be left on the gitignore as it is the default.