### PR TITLE
Added build time argument SHOPWARE_PACKAGES_TOKEN to make it …

### DIFF
--- a/shopware/docker/0.1/docker/Dockerfile
+++ b/shopware/docker/0.1/docker/Dockerfile
@@ -8,6 +8,8 @@ FROM ghcr.io/friendsofshopware/shopware-cli:latest-php-8.2 as shopware-cli
 
 FROM shopware-cli as build
 
+ARG SHOPWARE_PACKAGES_TOKEN
+
 ADD . /src
 WORKDIR /src
 


### PR DESCRIPTION
…available to shopware-cli in some environments/setups, e.g. coolify docker compose