### PR TITLE
Fix build scripts if CDPATH is set Bash

### DIFF
--- a/shopware/administration/6.4/bin/build-administration.sh
+++ b/shopware/administration/6.4/bin/build-administration.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+unset CDPATH
 CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"

--- a/shopware/administration/6.6/bin/build-administration.sh
+++ b/shopware/administration/6.6/bin/build-administration.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+unset CDPATH
 CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"

--- a/shopware/storefront/6.4/bin/build-storefront.sh
+++ b/shopware/storefront/6.4/bin/build-storefront.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+unset CDPATH
 CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
 set -euo pipefail

--- a/shopware/storefront/6.6/bin/build-storefront.sh
+++ b/shopware/storefront/6.6/bin/build-storefront.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+unset CDPATH
 CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
 set -euo pipefail


### PR DESCRIPTION
# Background

in my .bashrc i have

```
export CDPATH="./:$HOME/projects"
```

## Problem

$ bin/build-storefront.sh
/home/me/projects/example.com/bin/console: No such file or directory

The error message is a bit misleading, because that file actual does exist

## Debugging

```
~/projects/example.com$ CWD="$(cd -P -- "$(dirname -- "bin/build-storefront.sh")" && pwd -P)"
~/projects/example.com$ echo $CWD
./bin /home/me/projects/example.com/bin
```

So there is an additional output of the full directory.

This is because, if $CDPATH is set, `cd` prints the directory it changed to.

The fix is to unset CDPATH within the scripts scope.

This avoids also to `cd` to a very wrong directory