### PR TITLE
Remove default value for APP_SECRET

### DIFF
--- a/shopware/core/6.6/manifest.json
+++ b/shopware/core/6.6/manifest.json
@@ -40,7 +40,7 @@
     "env": {
         "APP_ENV": "prod",
         "APP_URL": "http://127.0.0.1:8000",
-        "APP_SECRET": "%generate(secret)%",
+        "APP_SECRET": "",
         "INSTANCE_ID": "%generate(secret)%",
         "BLUE_GREEN_DEPLOYMENT": "0",
         "DATABASE_URL": "mysql://root:root@localhost/shopware",


### PR DESCRIPTION
Having a secret generated for you is fun until you use gitleaks. AFAIK the secret should be different for each hosting stage (prod, quality, test, dev, ...) so forcing one to generate a value for each stage would be a better approach. One could also ignore .env in gitleaks but eventually you are ignoring the most vulnerable file for leaked secrets