### PR TITLE
fix: Make coding styles consistent with the Shopware platform

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,14 +1,17 @@
-; top-most EditorConfig file
+# Shopware recipes editor configuration normalization
+# http://editorconfig.org/
+
+# This is the top-most .editorconfig file; do not search in parent directories.
 root = true
 
-; Unix-style newlines
+# All files.
 [*]
-end_of_line = LF
-
-[*.{yml,yaml}]
+end_of_line = lf
 indent_style = space
 indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
 
-[*.json]
-indent_style = space
-indent_size = 4
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Editor config should be consistent over shopware components and its recipes.