### PR TITLE
fix: opentelemetry logging configuration

### DIFF
--- a/open-telemetry/opentelemetry-logger-monolog/1.0/config/packages/prod/opentelemetry_logger_monolog.yaml
+++ b/open-telemetry/opentelemetry-logger-monolog/1.0/config/packages/prod/opentelemetry_logger_monolog.yaml
@@ -1,0 +1,19 @@
+# see https://github.com/shopwareLabs/opentelemetry/blob/main/README.md
+
+monolog:
+    handlers:
+        main:
+            type: fingers_crossed
+            action_level: error
+            handler: nested
+            excluded_http_codes: [ 404, 405 ]
+            buffer_size: 50
+        nested:
+            type: service
+            id: monolog.handler.open_telemetry
+            level: error
+            formatter: null
+        # handler for shopware/elasticsearch, comment it out if package is not installed
+        elasticsearch:
+            type: service
+            id: monolog.handler.open_telemetry

--- a/open-telemetry/opentelemetry-logger-monolog/1.0/manifest.json
+++ b/open-telemetry/opentelemetry-logger-monolog/1.0/manifest.json
@@ -1,0 +1,5 @@
+{
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}

--- a/shopware/opentelemetry/0.1/config/packages/prod/opentelemetry.yaml
+++ b/shopware/opentelemetry/0.1/config/packages/prod/opentelemetry.yaml
@@ -3,12 +3,3 @@ shopware:
     profiler:
         integrations:
             - OpenTelemetry
-
-monolog:
-    handlers:
-        main:
-            type: service
-            id: monolog.handler.open_telemetry
-        elasticsearch:
-            type: service
-            id: monolog.handler.open_telemetry


### PR DESCRIPTION
# Fix OpenTelemetry logging configuration

With the current version of OpenTelemetry recipe, if configuration keys for monolog main handler are being merged with monolog configuration from docker, end config for main handler contains keys not supported by OpenTelemetry monolog handler.

Updated version extracts opentelemetry monolog handler to a separate recipe, that is executed only when `open-telemetry/opentelemetry-logger-monolog` package is installed. Configuration is based on configuration from the docker recipe, making them compatible.