### PR TITLE
Delete shopware/paas-meta/6.6/post-install.txt

### DIFF
--- a/shopware/paas-meta/6.6/post-install.txt
+++ b/shopware/paas-meta/6.6/post-install.txt
@@ -1,3 +1,0 @@
-* After first installation the Storefront will miss some css files
-  * To fix this dump the current theme configuration using <comment>platform mount:download --mount 'files' --target 'files' -A app</comment>
-  * Add that files to your git repository and push to build the storefront


### PR DESCRIPTION
The info is outdated not required anymore in 6.6