### PR TITLE
feat(k8s-meta): Disable plugin management from the UI

### DIFF
--- a/shopware/k8s-meta/1.0/config/packages/operator.yaml
+++ b/shopware/k8s-meta/1.0/config/packages/operator.yaml
@@ -22,6 +22,7 @@ shopware:
         enable_queue_stats_worker: false
     deployment:
         cluster_setup: true
+        runtime_extension_management: false
     cache:
         tagging:
             each_snippet: false


### PR DESCRIPTION
This pull request includes a small change to the `shopware/k8s-meta/1.0/config/packages/operator.yaml` file. The change adds a new configuration option for `runtime_extension_management` under the `deployment` section (see [documentation](https://developer.shopware.com/docs/guides/hosting/installation-updates/extension-managment.html#configuring-extension-manager-to-read-only-in-admin))

* [`shopware/k8s-meta/1.0/config/packages/operator.yaml`](diffhunk://#diff-a019c3b6407301585db50547ad2fe0c9239bfd700e5c877c66a39cd331c9ff8aR25): Added `runtime_extension_management` option set to `false` in the `deployment` section.