### PR TITLE
feat: Added argument support for watch-storefront command 

### DIFF
--- a/shopware/storefront/6.6/bin/watch-storefront.sh
+++ b/shopware/storefront/6.6/bin/watch-storefront.sh
@@ -39,7 +39,11 @@ fi
 "${CWD}"/console bundle:dump
 "${CWD}"/console feature:dump
 "${CWD}"/console theme:compile --active-only
-"${CWD}"/console theme:dump
+if [[ -n "$1" ]]; then
+    "${CWD}"/console theme:dump --theme-name="$1"
+else
+    "${CWD}"/console theme:dump
+fi
 
 if [[ $(command -v jq) ]]; then
     OLDPWD=$(pwd)

--- a/shopware/storefront/6.7/bin/watch-storefront.sh
+++ b/shopware/storefront/6.7/bin/watch-storefront.sh
@@ -41,7 +41,11 @@ fi
 "${CWD}"/console bundle:dump
 "${CWD}"/console feature:dump
 "${CWD}"/console theme:compile --active-only
-"${CWD}"/console theme:dump
+if [[ -n "$1" ]]; then
+    "${CWD}"/console theme:dump --theme-name="$1"
+else
+    "${CWD}"/console theme:dump
+fi
 
 if [[ $(command -v jq) ]]; then
     OLDPWD=$(pwd)


### PR DESCRIPTION
In combination with this PR: https://github.com/shopware/shopware/pull/6328

It allows you to run the watch-storefront command without interaction and without knowing the theme-id (which changes everytime)

```
./bin/watch-storefront MyTheme
```