### PR TITLE
chore(ci): update conflicts package for trunk

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
                         package: 6.6.x-dev
                         php: 8.2
                         node: 20
-                        conflict-version: ~0.2.0
+                        conflict-version: ~0.4.0
         env:
             APP_ENV: prod
             DATABASE_URL: mysql://root:root@127.0.0.1:3306/root


### PR DESCRIPTION
trunk needs `shopware/conflicts:>=0.4.0`

![image](https://github.com/user-attachments/assets/a7a463bc-7afc-4d8d-83a5-cac6c1fc39cb)
