### PR TITLE
fix: Add the missing Service bundle for SW 6.6

### DIFF
--- a/shopware/core/6.6/manifest.json
+++ b/shopware/core/6.6/manifest.json
@@ -30,6 +30,9 @@
         ],
         "Shopware\\Core\\Profiling\\Profiling": [
             "all"
+        ],
+        "Shopware\\Core\\Service\\Service": [
+            "all"
         ]
     },
     "container": {


### PR DESCRIPTION
Now, on Shopware 6.6 we are getting in the logs:

`User Deprecated: Since shopware/core : The Shopware\Core\Service\Service bundle should be added to config/bundles.php {"exception":"[object] (ErrorException(code: 0): User Deprecated: Since shopware/core : The Shopware\\Core\\Service\\Service bundle should be added to config/bundles.php at /app/vendor/shopware/core/Framework/Feature.php:255)"} []`