### PR TITLE
fix: Update symplify/phpstan-rules to version ^11.3

### DIFF
--- a/frosh/code-quality-meta/0.3/vendor-bin/phpstan/composer.json
+++ b/frosh/code-quality-meta/0.3/vendor-bin/phpstan/composer.json
@@ -4,7 +4,7 @@
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-symfony": "^1.3",
-        "symplify/phpstan-rules": "11.2.5.72"
+        "symplify/phpstan-rules": "^11.3"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
The package `symplify/phpstan-rules` depends on the `nette/utils` v3.2.10 which requires php >=7.2 <8.4.
The version v11.3 of  `symplify/phpstan-rules` works with PHP 8.4.