### PR TITLE
Feature/downgrade dependency for phpstan 1

### DIFF
--- a/frosh/code-quality-meta/0.4/root/.php-cs-fixer.dist.php
+++ b/frosh/code-quality-meta/0.4/root/.php-cs-fixer.dist.php
@@ -57,7 +57,6 @@ return (new Config())
     ->setCacheFile('var/cache/cs_fixer')
     ->setFinder(
         (new Finder())
-            ->in([__DIR__.'/custom/static-plugins/*/src',])
-            ->in([__DIR__.'/custom/plugins/*/src',])
+            ->in([__DIR__.'/custom'])
             ->exclude(['node_modules', '*/vendor/*'])
     );

--- a/frosh/code-quality-meta/0.4/vendor-bin/phpstan/composer.json
+++ b/frosh/code-quality-meta/0.4/vendor-bin/phpstan/composer.json
@@ -4,7 +4,7 @@
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-phpunit": "^1.4",
         "phpstan/phpstan-symfony": "^1.4",
-        "symplify/phpstan-rules": "^14.0",
+        "symplify/phpstan-rules": "^13.0",
         "rector/type-perfect": "1.0.0"
     },
     "config": {

--- a/frosh/code-quality-meta/0.5/root/.php-cs-fixer.dist.php
+++ b/frosh/code-quality-meta/0.5/root/.php-cs-fixer.dist.php
@@ -57,7 +57,6 @@ return (new Config())
     ->setCacheFile('var/cache/cs_fixer')
     ->setFinder(
         (new Finder())
-            ->in([__DIR__.'/custom/static-plugins/*/src',])
-            ->in([__DIR__.'/custom/plugins/*/src',])
+            ->in([__DIR__.'/custom'])
             ->exclude(['node_modules', '*/vendor/*'])
     );

--- a/frosh/code-quality-meta/0.5/vendor-bin/phpstan/composer.json
+++ b/frosh/code-quality-meta/0.5/vendor-bin/phpstan/composer.json
@@ -4,7 +4,7 @@
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-phpunit": "^1.4",
         "phpstan/phpstan-symfony": "^1.4",
-        "symplify/phpstan-rules": "^14.0",
+        "symplify/phpstan-rules": "^13.0",
         "rector/type-perfect": "1.0.0"
     },
     "config": {


### PR DESCRIPTION
Downgrade dependency to v13 since symplify/phpstan-rules v14 requires phpstan/phpstan ^2.0.