### PR TITLE
feat: Update Rector configuration and remove redundancy

### DIFF
--- a/frosh/code-quality-meta/0.4/root/rector.php
+++ b/frosh/code-quality-meta/0.4/root/rector.php
@@ -3,9 +3,8 @@
 declare(strict_types=1);
 
 use Frosh\Rector\Set\ShopwareSetList;
-use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
-use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
+use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 use Rector\Symfony\Set\SymfonySetList;
@@ -24,25 +23,17 @@ return RectorConfig::configure()
     ->withImportNames()
     ->withSkip([
         __DIR__ . '/custom/plugins/*/src/Migration',
-        __DIR__ . '/custom/static-plugins/*/src/Migration'
+        __DIR__ . '/custom/static-plugins/*/src/Migration',
+        AddOverrideAttributeToOverriddenMethodsRector::class,
     ])
     ->withRules([
-        InlineConstructorDefaultToPropertyRector::class,
         SimpleFunctionAndFilterRector::class,
     ])
     ->withSets([
         SetList::CODE_QUALITY,
         SetList::DEAD_CODE,
-        SymfonySetList::SYMFONY_54,
-        SymfonySetList::SYMFONY_60,
-        SymfonySetList::SYMFONY_61,
-        SymfonySetList::SYMFONY_62,
-        SymfonySetList::SYMFONY_63,
-        SymfonySetList::SYMFONY_64,
         SymfonySetList::SYMFONY_CODE_QUALITY,
         SymfonySetList::ANNOTATIONS_TO_ATTRIBUTES,
-        LevelSetList::UP_TO_PHP_81,
-        LevelSetList::UP_TO_PHP_82,
         LevelSetList::UP_TO_PHP_83,
         ShopwareSetList::SHOPWARE_6_5_0,
         ShopwareSetList::SHOPWARE_6_6_0,

--- a/frosh/code-quality-meta/0.5/root/rector.php
+++ b/frosh/code-quality-meta/0.5/root/rector.php
@@ -3,9 +3,8 @@
 declare(strict_types=1);
 
 use Frosh\Rector\Set\ShopwareSetList;
-use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
-use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
+use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 use Rector\Symfony\Set\SymfonySetList;
@@ -24,28 +23,19 @@ return RectorConfig::configure()
     ->withImportNames()
     ->withSkip([
         __DIR__ . '/custom/plugins/*/src/Migration',
-        __DIR__ . '/custom/static-plugins/*/src/Migration'
+        __DIR__ . '/custom/static-plugins/*/src/Migration',
+        AddOverrideAttributeToOverriddenMethodsRector::class,
     ])
     ->withRules([
-        InlineConstructorDefaultToPropertyRector::class,
         SimpleFunctionAndFilterRector::class,
     ])
     ->withSets([
         SetList::CODE_QUALITY,
         SetList::DEAD_CODE,
-        SymfonySetList::SYMFONY_54,
-        SymfonySetList::SYMFONY_60,
-        SymfonySetList::SYMFONY_61,
-        SymfonySetList::SYMFONY_62,
-        SymfonySetList::SYMFONY_63,
-        SymfonySetList::SYMFONY_64,
         SymfonySetList::SYMFONY_70,
         SymfonySetList::SYMFONY_71,
         SymfonySetList::SYMFONY_CODE_QUALITY,
         SymfonySetList::ANNOTATIONS_TO_ATTRIBUTES,
-        LevelSetList::UP_TO_PHP_81,
-        LevelSetList::UP_TO_PHP_82,
-        LevelSetList::UP_TO_PHP_83,
         LevelSetList::UP_TO_PHP_84,
         ShopwareSetList::SHOPWARE_6_5_0,
         ShopwareSetList::SHOPWARE_6_6_0,


### PR DESCRIPTION
Including all PHP level sets is redundant. Rector's level sets work because each higher level set includes all the rules from the lower level sets. So when you specify LevelSetList::UP_TO_PHP_84, it already contains all the rules from UP_TO_PHP_83, UP_TO_PHP_82, and UP_TO_PHP_81.
- Removed SYMFONY_54, SYMFONY_60, SYMFONY_61, and SYMFONY_62 since they're already included in SHOPWARE_6_5_0
- Removed SYMFONY_63 and SYMFONY_64 since they're already included in SHOPWARE_6_6_0