### PR TITLE
fix: install only prod dependencies

### DIFF
--- a/shopware/administration/6.7/bin/build-administration.sh
+++ b/shopware/administration/6.7/bin/build-administration.sh
@@ -70,7 +70,7 @@ if [[ $(command -v jq) ]]; then
         if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "administration" ]]; then
             echo "=> Installing npm dependencies for ${name}"
 
-            npm install --prefix "$path" --no-audit --prefer-offline
+            npm install --omit=dev --prefix "$path" --no-audit --prefer-offline
         fi
     done
     cd "$OLDPWD" || exit

--- a/shopware/administration/6.7/bin/watch-administration.sh
+++ b/shopware/administration/6.7/bin/watch-administration.sh
@@ -56,7 +56,7 @@ if [[ $(command -v jq) ]]; then
         if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "administration" ]]; then
             echo "=> Installing npm dependencies for ${name}"
 
-            npm install --prefix "$path"
+            npm install --omit=dev --prefix "$path"
         fi
     done
     cd "$OLDPWD" || exit


### PR DESCRIPTION
Dev dependencies shouldn't be required for the package to be built. In the future, commercial will not be buildable in alternative ways, such as as a composer dependency, without this change.