### PR TITLE
feat: add persistent redis-cache for paas

### DIFF
--- a/shopware/paas-meta/6.4/.platform/applications.yaml
+++ b/shopware/paas-meta/6.4/.platform/applications.yaml
@@ -16,9 +16,6 @@
             # NVM and Node.js versions to install
             NVM_VERSION: v0.39.0
             NODE_VERSION: v18
-            # Use different redis dbs for cache and sessions
-            REDIS_CACHE_DATABASE: 0
-            REDIS_SESSION_DATABASE: 2
             # Improve admin build speed
             DISABLE_ADMIN_COMPILATION_TYPECHECK: 1
             # Only build extension. Shopware assets are pre built in the tags
@@ -209,6 +206,7 @@
     relationships:
         database: "db:mysql"
         rediscache: "cacheredis:redis"
+        redissession: "sessionredis:redis"
         # comment to disable rabbitmq
         rabbitmqqueue: "rabbitmq:rabbitmq"
         # uncomment if you want to use opensearch/elasticsearch

--- a/shopware/paas-meta/6.4/.platform/services.yaml
+++ b/shopware/paas-meta/6.4/.platform/services.yaml
@@ -5,6 +5,11 @@ cacheredis:
     type: redis:7.0
     configuration:
         maxmemory_policy: volatile-lfu
+sessionredis:
+    type: redis-persistent:7.0
+    disk: 1024
+    configuration:
+        maxmemory_policy: allkeys-lru
 # comment if you want to disable rabbitmq
 rabbitmq:
     type: rabbitmq:3.8

--- a/shopware/paas-meta/6.4/config/packages/paas.yaml
+++ b/shopware/paas-meta/6.4/config/packages/paas.yaml
@@ -2,11 +2,11 @@
 
 framework:
     session:
-        handler_id: "%env(CACHE_URL)%/%env(int:default:default_redis_database:REDIS_SESSION_DATABASE)%"
+        handler_id: "%env(SESSION_REDIS_URL)%/0"
     cache:
         app: cache.adapter.redis
         system: cache.adapter.redis
-        default_redis_provider: "%env(CACHE_URL)%/%env(int:default:default_redis_database:REDIS_CACHE_DATABASE)%"
+        default_redis_provider: "%env(CACHE_URL)%/0"
 
 shopware:
     api:

--- a/shopware/paas-meta/6.5/.platform/applications.yaml
+++ b/shopware/paas-meta/6.5/.platform/applications.yaml
@@ -109,6 +109,7 @@
     relationships:
         database: "db:mysql"
         rediscache: "cacheredis:redis"
+        redissession: "sessionredis:redis"
         # comment to disable rabbitmq
         rabbitmqqueue: "rabbitmq:rabbitmq"
         # uncomment if you want to use opensearch/elasticsearch

--- a/shopware/paas-meta/6.5/.platform/services.yaml
+++ b/shopware/paas-meta/6.5/.platform/services.yaml
@@ -5,6 +5,11 @@ cacheredis:
     type: redis:7.0
     configuration:
         maxmemory_policy: volatile-lfu
+sessionredis:
+    type: redis-persistent:7.0
+    disk: 1024
+    configuration:
+        maxmemory_policy: allkeys-lru
 # comment if you want to disable rabbitmq
 rabbitmq:
     type: rabbitmq:3.8

--- a/shopware/paas-meta/6.5/config/packages/paas.yaml
+++ b/shopware/paas-meta/6.5/config/packages/paas.yaml
@@ -3,11 +3,11 @@
 
 framework:
     session:
-        handler_id: "%env(SESSION_REDIS_URL)%/0"
+        handler_id: "%env(SESSION_REDIS_URL)%/0?persistent=1"
     cache:
         app: cache.adapter.redis
         system: cache.adapter.redis
-        default_redis_provider: "%env(CACHE_URL)%/0"
+        default_redis_provider: "%env(CACHE_URL)%/0?persistent=1"
 
 shopware:
     api:

--- a/shopware/paas-meta/6.5/config/packages/paas.yaml
+++ b/shopware/paas-meta/6.5/config/packages/paas.yaml
@@ -3,7 +3,7 @@
 
 framework:
     session:
-        handler_id: "%env(CACHE_URL)%/2"
+        handler_id: "%env(SESSION_REDIS_URL)%/0"
     cache:
         app: cache.adapter.redis
         system: cache.adapter.redis

--- a/shopware/paas-meta/6.6/.platform/applications.yaml
+++ b/shopware/paas-meta/6.6/.platform/applications.yaml
@@ -110,6 +110,7 @@
     relationships:
         database: "db:mysql"
         rediscache: "cacheredis:redis"
+        redissession: "sessionredis:redis"
         # comment to disable rabbitmq
         rabbitmqqueue: "rabbitmq:rabbitmq"
         # uncomment if you want to use opensearch/elasticsearch

--- a/shopware/paas-meta/6.6/.platform/services.yaml
+++ b/shopware/paas-meta/6.6/.platform/services.yaml
@@ -6,6 +6,13 @@ cacheredis:
     type: redis:7.2
     configuration:
         maxmemory_policy: volatile-lfu
+
+sessionredis:
+    type: redis-persistent:7.2
+    disk: 1024
+    configuration:
+        maxmemory_policy: allkeys-lru
+
 # comment if you want to disable rabbitmq
 rabbitmq:
     type: rabbitmq:3.13

--- a/shopware/paas-meta/6.6/config/packages/paas.yaml
+++ b/shopware/paas-meta/6.6/config/packages/paas.yaml
@@ -3,11 +3,11 @@
 
 framework:
     session:
-        handler_id: "%env(SESSION_REDIS_URL)%/0"
+        handler_id: "%env(SESSION_REDIS_URL)%/0?persistent=1"
     cache:
         app: cache.adapter.redis
         system: cache.adapter.redis
-        default_redis_provider: "%env(CACHE_URL)%/0"
+        default_redis_provider: "%env(CACHE_URL)%/0?persistent=1"
 
 shopware:
     api:

--- a/shopware/paas-meta/6.6/config/packages/paas.yaml
+++ b/shopware/paas-meta/6.6/config/packages/paas.yaml
@@ -3,7 +3,7 @@
 
 framework:
     session:
-        handler_id: "%env(CACHE_URL)%/2"
+        handler_id: "%env(SESSION_REDIS_URL)%/0"
     cache:
         app: cache.adapter.redis
         system: cache.adapter.redis


### PR DESCRIPTION
fixes https://github.com/shopware/recipes/issues/176

adds a persistent redis session config for platform.sh

https://github.com/shopware/paas-meta/blob/main/platformsh-env.php has the logic already and sets a env var SESSION_REDIS_URL if a redissession relationship is found. 

that url is now used as session-url instead of CACHE_URL