### PR TITLE
fix: paas: add low_prioriy to message:consume

### DIFF
--- a/shopware/paas-meta/6.4/.platform/applications.yaml
+++ b/shopware/paas-meta/6.4/.platform/applications.yaml
@@ -265,7 +265,7 @@
         queue:
             disk: 128
             commands:
-                start: bin/console messenger:consume async failed --memory-limit=$(cat /run/config.json | jq .info.limits.memory)M --time-limit=295
+                start: bin/console messenger:consume async low_priority failed --memory-limit=$(cat /run/config.json | jq .info.limits.memory)M --time-limit=295
 
     crons:
         scheduler:

--- a/shopware/paas-meta/6.5/.platform/applications.yaml
+++ b/shopware/paas-meta/6.5/.platform/applications.yaml
@@ -161,7 +161,7 @@
         queue:
             disk: 128
             commands:
-                start: APP_CACHE_DIR=/app/localCache bin/console messenger:consume async failed --memory-limit=$(cat /run/config.json | jq .info.limits.memory)M --time-limit=295
+                start: APP_CACHE_DIR=/app/localCache bin/console messenger:consume async low_priority failed --memory-limit=$(cat /run/config.json | jq .info.limits.memory)M --time-limit=295
 
     crons:
         scheduler:

--- a/shopware/paas-meta/6.6/.platform/applications.yaml
+++ b/shopware/paas-meta/6.6/.platform/applications.yaml
@@ -162,7 +162,7 @@
         queue:
             disk: 128
             commands:
-                start: APP_CACHE_DIR=/app/localCache bin/console messenger:consume async failed --memory-limit=$(cat /run/config.json | jq .info.limits.memory)M --time-limit=295
+                start: APP_CACHE_DIR=/app/localCache bin/console messenger:consume async low_priority failed --memory-limit=$(cat /run/config.json | jq .info.limits.memory)M --time-limit=295
 
     crons:
         scheduler:


### PR DESCRIPTION
the low_priority queue is missing in the consumer call for paas