### PR TITLE
fix: route sitemap through storefront controller

### DIFF
--- a/shopware/core/6.7/public/.htaccess.dist
+++ b/shopware/core/6.7/public/.htaccess.dist
@@ -26,7 +26,7 @@ DirectoryIndex index.php
     RewriteRule ^ - [L]
 
     # Rewrite all other queries to the front controller.
-    RewriteCond %{REQUEST_URI} !^/(theme|media|thumbnail|bundles|css|fonts|js|recovery|sitemap) [NC]    
+    RewriteCond %{REQUEST_URI} !^/(theme|media|thumbnail|bundles|css|fonts|js|recovery) [NC]
     RewriteRule ^ %{ENV:BASE}/index.php [L]
 </IfModule>
 


### PR DESCRIPTION
This PR updates the `.htaccess` rewrite conditions to **_exclude_** `/sitemap.xml` from being treated as a static file.  
Previously, adding `sitemap` to the list of exclusions caused a `404 Not Found`, as Shopware dynamically generates the sitemap via Symfony routes.

Fixes: https://github.com/shopware/shopware/issues/8091