### PR TITLE
fix(htaccess): update rewrite condition

### DIFF
--- a/shopware/core/6.7/public/.htaccess.dist
+++ b/shopware/core/6.7/public/.htaccess.dist
@@ -26,7 +26,7 @@ DirectoryIndex index.php
     RewriteRule ^ - [L]
 
     # Rewrite all other queries to the front controller.
-    RewriteCond %{REQUEST_URI} !^/(theme|media|thumbnail|bundles|css|fonts|js|recovery) [NC]
+    RewriteCond %{REQUEST_URI} !^/(theme|media|thumbnail|bundles|css|fonts|js|recovery)/ [NC]
     RewriteRule ^ %{ENV:BASE}/index.php [L]
 </IfModule>
 


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/shopware/recipes/issues/183), the regex to rewrite queries to the front controller should be added a slash at the end so URLs like `/themenwelten` for example will not result in a 404.

closes https://github.com/shopware/recipes/issues/183