### PR TITLE
revert APP_SECRET change for 6.7

### DIFF
--- a/shopware/core/6.7/manifest.json
+++ b/shopware/core/6.7/manifest.json
@@ -43,15 +43,10 @@
     "env": {
         "APP_ENV": "prod",
         "APP_URL": "http://127.0.0.1:8000",
-        "APP_SECRET": "",
+        "APP_SECRET": "%generate(secret)%",
         "INSTANCE_ID": "%generate(secret)%",
         "BLUE_GREEN_DEPLOYMENT": "0",
         "DATABASE_URL": "mysql://root:root@localhost/shopware"
-    },
-    "dotenv": {
-        "local": {
-            "APP_SECRET": "%generate(secret)%"
-        }
     },
     "gitignore": [
         ".env.local",


### PR DESCRIPTION
After updating from 6.6 to 6.7 we have a `.env.local` like this

```
APP_ENV=prod
APP_URL=xxx
APP_SECRET=ZR6RUDZQVXRnr4iMQFY3PAXevYDStlyHmUvEAPJnwVW8Lg7jEFcBdLzcUUnmFaf0

###> shopware/core ###
APP_SECRET=6d51a2d8baf0a55d79cc0f47a21d8b67
###< shopware/core ###
```

This will cause A LOT of issues. revert it for now we need todo it proper without breaking setups outside