### PR TITLE
configured Shopware to proxy sitemap files

### DIFF
--- a/shopware/k8s-meta/1.0/config/packages/operator.yaml
+++ b/shopware/k8s-meta/1.0/config/packages/operator.yaml
@@ -54,6 +54,14 @@ shopware:
                 endpoint: "%env(K8S_FILESYSTEM_ENDPOINT)%"
                 use_path_style_endpoint: true
         theme: *public_bucket
+        sitemap:
+            type: "amazon-s3"
+            url: "%env(K8S_FILESYSTEM_PUBLIC_URL)%"
+            visibility: "public"
+            config:
+                bucket: "%env(K8S_FILESYSTEM_PUBLIC_BUCKET)%"
+                region: "%env(K8S_FILESYSTEM_REGION)%"
+                endpoint: "%env(K8S_FILESYSTEM_ENDPOINT)%"
         asset:
             type: local
             url: '%env(APP_URL)%'


### PR DESCRIPTION
This pull request introduces a new configuration for the `sitemap` in the `shopware` operator's Kubernetes meta package. The update adds support for storing sitemaps in an Amazon S3 bucket.

### New `sitemap` configuration:
* Added a `sitemap` section in `shopware/k8s-meta/1.0/config/packages/operator.yaml` to configure Amazon S3 as the storage type. This includes specifying the bucket, region, endpoint, and public visibility settings.