### PR TITLE
Fix 6.7 export env variables

### DIFF
--- a/shopware/administration/6.6/bin/build-administration.sh
+++ b/shopware/administration/6.6/bin/build-administration.sh
@@ -75,7 +75,7 @@ else
     echo "Cannot check extensions for required npm installations as jq is not installed"
 fi
 
-(cd "${ADMIN_ROOT}"/Resources/app/administration && npm install --prefer-offline --production)
+(cd "${ADMIN_ROOT}"/Resources/app/administration && npm install --prefer-offline --omit=dev)
 
 # Dump entity schema
 if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP:-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then

--- a/shopware/administration/6.7/bin/build-administration.sh
+++ b/shopware/administration/6.7/bin/build-administration.sh
@@ -26,7 +26,6 @@ set -euo pipefail
 export APP_URL
 export PROJECT_ROOT
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-export DISABLE_ADMIN_COMPILATION_TYPECHECK=true
 
 if [[ -e "${PROJECT_ROOT}/vendor/shopware/platform" ]]; then
     ADMIN_ROOT="${ADMIN_ROOT:-"${PROJECT_ROOT}/vendor/shopware/platform/src/Administration"}"
@@ -78,7 +77,7 @@ else
     echo "Cannot check extensions for required npm installations as jq is not installed"
 fi
 
-(cd "${ADMIN_ROOT}"/Resources/app/administration && npm install --prefer-offline --production)
+(cd "${ADMIN_ROOT}"/Resources/app/administration && npm install --prefer-offline --omit=dev)
 
 # Dump entity schema
 if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP:-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then

--- a/shopware/administration/6.7/bin/watch-administration.sh
+++ b/shopware/administration/6.7/bin/watch-administration.sh
@@ -18,10 +18,12 @@ eval "$curenv"
 set +o allexport
 
 export HOST=${HOST:-"localhost"}
-export ESLINT_DISABLE
-export PORT
+export VITE_HOST
+export ADMIN_PORT
 export APP_URL
-export DISABLE_ADMIN_COMPILATION_TYPECHECK=1
+export SHOPWARE_ADMIN_SKIP_SOURCEMAP_GENERATION
+export DISABLE_DEVSERVER_OPEN
+export DDEV_PRIMARY_URL
 
 if [[ -e "${PROJECT_ROOT}/vendor/shopware/platform" ]]; then
     ADMIN_ROOT="${ADMIN_ROOT:-"${PROJECT_ROOT}/vendor/shopware/platform/src/Administration"}"

--- a/shopware/platform/6.6/bin/build-administration.sh
+++ b/shopware/platform/6.6/bin/build-administration.sh
@@ -75,7 +75,7 @@ else
     echo "Cannot check extensions for required npm installations as jq is not installed"
 fi
 
-(cd "${ADMIN_ROOT}"/Resources/app/administration && npm install --prefer-offline --production)
+(cd "${ADMIN_ROOT}"/Resources/app/administration && npm install --prefer-offline --omit=dev)
 
 # Dump entity schema
 if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP:-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then

--- a/shopware/platform/6.6/bin/build-storefront.sh
+++ b/shopware/platform/6.6/bin/build-storefront.sh
@@ -59,7 +59,7 @@ else
     echo "Cannot check extensions for required npm installations as jq is not installed"
 fi
 
-npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --prefer-offline --production
+npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --prefer-offline --omit=dev
 node "${STOREFRONT_ROOT}"/Resources/app/storefront/copy-to-vendor.js
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run production
 [[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install

--- a/shopware/platform/6.7/bin/build-administration.sh
+++ b/shopware/platform/6.7/bin/build-administration.sh
@@ -26,7 +26,6 @@ set -euo pipefail
 export APP_URL
 export PROJECT_ROOT
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-export DISABLE_ADMIN_COMPILATION_TYPECHECK=true
 
 if [[ -e "${PROJECT_ROOT}/vendor/shopware/platform" ]]; then
     ADMIN_ROOT="${ADMIN_ROOT:-"${PROJECT_ROOT}/vendor/shopware/platform/src/Administration"}"
@@ -78,7 +77,7 @@ else
     echo "Cannot check extensions for required npm installations as jq is not installed"
 fi
 
-(cd "${ADMIN_ROOT}"/Resources/app/administration && npm install --prefer-offline --production)
+(cd "${ADMIN_ROOT}"/Resources/app/administration && npm install --prefer-offline --omit=dev)
 
 # Dump entity schema
 if [[ -z "${SHOPWARE_SKIP_ENTITY_SCHEMA_DUMP:-""}" ]] && [[ -f "${ADMIN_ROOT}"/Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts ]]; then

--- a/shopware/platform/6.7/bin/build-storefront.sh
+++ b/shopware/platform/6.7/bin/build-storefront.sh
@@ -59,7 +59,7 @@ else
     echo "Cannot check extensions for required npm installations as jq is not installed"
 fi
 
-npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --prefer-offline --production
+npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --prefer-offline --omit=dev
 node "${STOREFRONT_ROOT}"/Resources/app/storefront/copy-to-vendor.js
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run production
 [[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install

--- a/shopware/platform/6.7/bin/watch-administration.sh
+++ b/shopware/platform/6.7/bin/watch-administration.sh
@@ -18,10 +18,12 @@ eval "$curenv"
 set +o allexport
 
 export HOST=${HOST:-"localhost"}
-export ESLINT_DISABLE
-export PORT
+export VITE_HOST
+export ADMIN_PORT
 export APP_URL
-export DISABLE_ADMIN_COMPILATION_TYPECHECK=1
+export SHOPWARE_ADMIN_SKIP_SOURCEMAP_GENERATION
+export DISABLE_DEVSERVER_OPEN
+export DDEV_PRIMARY_URL
 
 if [[ -e "${PROJECT_ROOT}/vendor/shopware/platform" ]]; then
     ADMIN_ROOT="${ADMIN_ROOT:-"${PROJECT_ROOT}/vendor/shopware/platform/src/Administration"}"

--- a/shopware/storefront/6.6/bin/build-storefront.sh
+++ b/shopware/storefront/6.6/bin/build-storefront.sh
@@ -59,7 +59,7 @@ else
     echo "Cannot check extensions for required npm installations as jq is not installed"
 fi
 
-npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --prefer-offline --production
+npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --prefer-offline --omit=dev
 node "${STOREFRONT_ROOT}"/Resources/app/storefront/copy-to-vendor.js
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run production
 [[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install

--- a/shopware/storefront/6.7/bin/build-storefront.sh
+++ b/shopware/storefront/6.7/bin/build-storefront.sh
@@ -59,7 +59,7 @@ else
     echo "Cannot check extensions for required npm installations as jq is not installed"
 fi
 
-npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --prefer-offline --production
+npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --prefer-offline --omit=dev
 node "${STOREFRONT_ROOT}"/Resources/app/storefront/copy-to-vendor.js
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run production
 [[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently, there are several deprecated env var exports in the 6.7 versions of the administration scripts that were used in the past for the old Webpack setup, but no longer fully work with the new Vite setup
  - `DISABLE_ADMIN_COMPILATION_TYPECHECK` no longer exists
  - `ESLINT_DISABLE` no longer exists
  - `PORT` no longer exists
  - `VITE_HOST` was missing in the export
  - `ADMIN_PORT` was missing in the export
  - `SHOPWARE_ADMIN_SKIP_SOURCEMAP_GENERATION` was missing in the export
  - `DISABLE_DEVSERVER_OPEN` was missing in the export
  - `DDEV_PRIMARY_URL` was missing in the export
- The npm `--production` flag is deprecated and should be replaced with the by npm suggested `--omit=dev` flag, which was also already used in other scripts correctly

### 2. What does this change do, exactly?
- Changed deprecated `--production` to suggested `--omit=dev`

### 3. Describe each step to reproduce the issue or behaviour.
- e.g. try to change the vite port in a 6.7 platform / symfony flex setup