### PR TITLE
chore: prevent relative paths in plugin package-lock.json files

### DIFF
--- a/shopware/administration/6.7/bin/build-administration.sh
+++ b/shopware/administration/6.7/bin/build-administration.sh
@@ -69,7 +69,7 @@ if [[ $(command -v jq) ]]; then
         if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "administration" ]]; then
             echo "=> Installing npm dependencies for ${name}"
 
-            npm install --omit=dev --prefix "$path" --no-audit --prefer-offline
+            (cd "$path" && npm install --omit=dev --no-audit --prefer-offline)
         fi
     done
     cd "$OLDPWD" || exit

--- a/shopware/administration/6.7/bin/watch-administration.sh
+++ b/shopware/administration/6.7/bin/watch-administration.sh
@@ -58,7 +58,7 @@ if [[ $(command -v jq) ]]; then
         if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "administration" ]]; then
             echo "=> Installing npm dependencies for ${name}"
 
-            npm install --omit=dev --prefix "$path"
+            (cd "$path" && npm install --omit=dev)
         fi
     done
     cd "$OLDPWD" || exit

--- a/shopware/platform/6.7/bin/build-administration.sh
+++ b/shopware/platform/6.7/bin/build-administration.sh
@@ -69,7 +69,7 @@ if [[ $(command -v jq) ]]; then
         if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "administration" ]]; then
             echo "=> Installing npm dependencies for ${name}"
 
-            npm install --omit=dev --prefix "$path" --no-audit --prefer-offline
+            (cd "$path" && npm install --omit=dev --no-audit --prefer-offline)
         fi
     done
     cd "$OLDPWD" || exit

--- a/shopware/platform/6.7/bin/build-storefront.sh
+++ b/shopware/platform/6.7/bin/build-storefront.sh
@@ -51,7 +51,7 @@ if [[ $(command -v jq) ]]; then
         if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "storefront" ]]; then
             echo "=> Installing npm dependencies for ${name}"
 
-            npm install --prefix "$path" --prefer-offline
+            (cd "$path" && npm install --prefer-offline)
         fi
     done
     cd "$OLDPWD" || exit

--- a/shopware/platform/6.7/bin/watch-administration.sh
+++ b/shopware/platform/6.7/bin/watch-administration.sh
@@ -58,7 +58,7 @@ if [[ $(command -v jq) ]]; then
         if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "administration" ]]; then
             echo "=> Installing npm dependencies for ${name}"
 
-            npm install --omit=dev --prefix "$path"
+            (cd "$path" && npm install --omit=dev)
         fi
     done
     cd "$OLDPWD" || exit

--- a/shopware/platform/6.7/bin/watch-storefront.sh
+++ b/shopware/platform/6.7/bin/watch-storefront.sh
@@ -67,7 +67,7 @@ if [[ $(command -v jq) ]]; then
         if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "storefront" ]]; then
             echo "=> Installing npm dependencies for ${name}"
 
-            npm install --prefix "$path"
+            (cd "$path" && npm install)
         fi
     done
     cd "$OLDPWD" || exit

--- a/shopware/storefront/6.7/bin/build-storefront.sh
+++ b/shopware/storefront/6.7/bin/build-storefront.sh
@@ -51,7 +51,7 @@ if [[ $(command -v jq) ]]; then
         if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "storefront" ]]; then
             echo "=> Installing npm dependencies for ${name}"
 
-            npm install --prefix "$path" --prefer-offline
+            (cd "$path" && npm install --prefer-offline)
         fi
     done
     cd "$OLDPWD" || exit

--- a/shopware/storefront/6.7/bin/watch-storefront.sh
+++ b/shopware/storefront/6.7/bin/watch-storefront.sh
@@ -67,7 +67,7 @@ if [[ $(command -v jq) ]]; then
         if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "storefront" ]]; then
             echo "=> Installing npm dependencies for ${name}"
 
-            npm install --prefix "$path"
+            (cd "$path" && npm install)
         fi
     done
     cd "$OLDPWD" || exit


### PR DESCRIPTION
When building administration/storefront of a plugin which only contains a package.json but no node_modules and package-lock.json, the build scripts create a package-lock.json with relative paths to the plugin's node_modules folder.

To fix this, I've changed the `npm install` commands to change directory into `$path` beforehand and removed the `--prefix=$path` from the install command.

Before:
`npm install --omit=dev --prefix "$path" --no-audit --prefer-offline`
After:
`(cd "$path" && npm install --omit=dev --no-audit --prefer-offline)`