### PR TITLE
feat: enable mailer worker on operator

### DIFF
--- a/shopware/k8s-meta/2.0/config/packages/operator.yaml
+++ b/shopware/k8s-meta/2.0/config/packages/operator.yaml
@@ -73,3 +73,5 @@ framework:
     cache:
         app: cache.adapter.redis_tag_aware
         default_redis_provider: 'redis://%env(K8S_CACHE_HOST)%:%env(K8S_CACHE_PORT)%/%env(K8S_CACHE_INDEX)%'
+    mailer:
+        message_bus: 'messenger.default_bus'


### PR DESCRIPTION
This makes sure the worker is used for email sending. Since the
helm-chart has support for workers we define this here
