### PR TITLE
feat: add Adminer container to docker-dev recipe

### DIFF
--- a/shopware/docker-dev/0.1/manifest.json
+++ b/shopware/docker-dev/0.1/manifest.json
@@ -22,6 +22,15 @@
                 "  depends_on:",
                 "    database:",
                 "      condition: service_healthy"
+            ],
+            "adminer:": [
+                "  image: adminer",
+                "  stop_signal: SIGKILL",
+                "  depends_on: [ database ]",
+                "  environment:",
+                "    ADMINER_DEFAULT_SERVER: database",
+                "  ports:",
+                "    - '9080:8080'"
             ]
         }
     },


### PR DESCRIPTION
## Summary
- Adds Adminer database management tool to the docker-dev recipe
- Configured to run on port 9080 for easy database administration
- Pre-configured to connect to the database service

## Test plan
- [ ] Run `make up` to start the Docker environment
- [ ] Access Adminer at http://localhost:9080
- [ ] Verify connection to database works with credentials root/root

🤖 Generated with [Claude Code](https://claude.ai/code)