### PR TITLE
fix: Use the `ComposerPluginLoader` when enabled in the `bin/{console/shopware}` command

### DIFF
--- a/shopware/core/6.6/bin/console
+++ b/shopware/core/6.6/bin/console
@@ -2,6 +2,7 @@
 <?php
 
 use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
+use Shopware\Core\Framework\Plugin\KernelPluginLoader\ComposerPluginLoader;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\DbalKernelPluginLoader;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
 use Shopware\Core\Kernel;
@@ -39,15 +40,20 @@ return static function (array &$context) {
         $context['INSTALL'] = true;
     }
 
-    if (trim($context['DATABASE_URL'] ?? '') !== '' && !isset($context['INSTALL'])) {
-        $pluginLoader = new DbalKernelPluginLoader($classLoader, null, Kernel::getConnection());
+    if (!isset($context['INSTALL'])) {
+        $useComposerPluginLoader = (bool) ($context['COMPOSER_PLUGIN_LOADER'] ?? false);
+        if ($useComposerPluginLoader) {
+            $pluginLoader = new ComposerPluginLoader($classLoader, null);
+        } elseif (trim($context['DATABASE_URL'] ?? '') !== '') {
+            $pluginLoader = new DbalKernelPluginLoader($classLoader, null, Kernel::getConnection());
+        }
     }
 
     $kernel = KernelFactory::create(
         environment: $env,
         debug: $debug,
         classLoader: $classLoader,
-        pluginLoader: $pluginLoader
+        pluginLoader: $pluginLoader,
     );
 
     $application = new Application($kernel);

--- a/shopware/core/6.7/bin/console
+++ b/shopware/core/6.7/bin/console
@@ -2,6 +2,7 @@
 <?php
 
 use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
+use Shopware\Core\Framework\Plugin\KernelPluginLoader\ComposerPluginLoader;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\DbalKernelPluginLoader;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
 use Shopware\Core\Kernel;
@@ -39,15 +40,20 @@ return static function (array &$context) {
         $context['INSTALL'] = true;
     }
 
-    if (trim($context['DATABASE_URL'] ?? '') !== '' && !isset($context['INSTALL'])) {
-        $pluginLoader = new DbalKernelPluginLoader($classLoader, null, Kernel::getConnection());
+    if (!isset($context['INSTALL'])) {
+        $useComposerPluginLoader = (bool) ($context['COMPOSER_PLUGIN_LOADER'] ?? false);
+        if ($useComposerPluginLoader) {
+            $pluginLoader = new ComposerPluginLoader($classLoader, null);
+        } elseif (trim($context['DATABASE_URL'] ?? '') !== '') {
+            $pluginLoader = new DbalKernelPluginLoader($classLoader, null, Kernel::getConnection());
+        }
     }
 
     $kernel = KernelFactory::create(
         environment: $env,
         debug: $debug,
         classLoader: $classLoader,
-        pluginLoader: $pluginLoader
+        pluginLoader: $pluginLoader,
     );
 
     $application = new Application($kernel);


### PR DESCRIPTION
https://github.com/shopware/shopware/pull/13161

Note as Shopware 6.4 did not have the `ComposerPluginLoader` I did not adjust the recipe for that version. 
This is also used for Shopware 6.5 however I would not consider this a security fix.