### PR TITLE
upgrade to php 8.3 in devenv.nix

### DIFF
--- a/frosh/devenv-meta/0.3/root/devenv.nix
+++ b/frosh/devenv-meta/0.3/root/devenv.nix
@@ -16,7 +16,7 @@
 
   languages.php = {
     enable = lib.mkDefault true;
-    version = lib.mkDefault "8.2";
+    version = lib.mkDefault "8.3";
 
     ini = ''
       memory_limit = 2G


### PR DESCRIPTION
Since atleast shopware/core v6.6.0.0 the package lcobucci/clock: ^3.1.0 is required.
Since ^ means up to and not including lcobucci/clock: 4.0.0 the package that will be installed is currently: lcobucci/clock 3.5.0 which requires  php (~8.3.0 || ~8.4.0 || ~8.5.0) meaning the devenv environment wont work with php 8.2 .