### PR TITLE
fixes: #216 | remove process substitution in while loops

### DIFF
--- a/shopware/administration/6.7/bin/build-administration.sh
+++ b/shopware/administration/6.7/bin/build-administration.sh
@@ -55,7 +55,7 @@ if [[ $(command -v jq) ]]; then
 
     basePaths=()
 
-    while read -r config; do
+    jq -c '.[]' "var/plugins.json" | while read -r config; do
         srcPath=$(echo "$config" | jq -r '(.basePath + .administration.path)')
         basePath=$(echo "$config" | jq -r '.basePath')
 
@@ -78,7 +78,7 @@ if [[ $(command -v jq) ]]; then
 
             (cd "$path" && npm install --omit=dev --no-audit --prefer-offline)
         fi
-    done < <(jq -c '.[]' "var/plugins.json")
+    done
 
     for basePath in "${basePaths[@]}"; do
         if [[ -r "${basePath}/package.json" ]]; then

--- a/shopware/platform/6.7/bin/build-administration.sh
+++ b/shopware/platform/6.7/bin/build-administration.sh
@@ -55,7 +55,7 @@ if [[ $(command -v jq) ]]; then
 
     basePaths=()
 
-    while read -r config; do
+    jq -c '.[]' "var/plugins.json" | while read -r config; do
         srcPath=$(echo "$config" | jq -r '(.basePath + .administration.path)')
         basePath=$(echo "$config" | jq -r '.basePath')
 
@@ -78,7 +78,7 @@ if [[ $(command -v jq) ]]; then
 
             (cd "$path" && npm install --omit=dev --no-audit --prefer-offline)
         fi
-    done < <(jq -c '.[]' "var/plugins.json")
+    done
 
     for basePath in "${basePaths[@]}"; do
         if [[ -r "${basePath}/package.json" ]]; then

--- a/shopware/platform/6.7/bin/build-storefront.sh
+++ b/shopware/platform/6.7/bin/build-storefront.sh
@@ -36,7 +36,7 @@ if [[ $(command -v jq) ]]; then
     cd "$PROJECT_ROOT" || exit
     basePaths=()
 
-    while read -r config; do
+    jq -c '.[]' "var/plugins.json" | while read -r config; do
         srcPath=$(echo "$config" | jq -r '(.basePath + .storefront.path)')
         basePath=$(echo "$config" | jq -r '.basePath')
 
@@ -59,7 +59,7 @@ if [[ $(command -v jq) ]]; then
 
             (cd "$path" && npm install --prefer-offline)
         fi
-    done < <(jq -c '.[]' "var/plugins.json")
+    done
 
     for basePath in "${basePaths[@]}"; do
         if [[ -r "${basePath}/package.json" ]]; then

--- a/shopware/storefront/6.7/bin/build-storefront.sh
+++ b/shopware/storefront/6.7/bin/build-storefront.sh
@@ -36,7 +36,7 @@ if [[ $(command -v jq) ]]; then
     cd "$PROJECT_ROOT" || exit
     basePaths=()
 
-    while read -r config; do
+    jq -c '.[]' "var/plugins.json" | while read -r config; do
         srcPath=$(echo "$config" | jq -r '(.basePath + .storefront.path)')
         basePath=$(echo "$config" | jq -r '.basePath')
 
@@ -60,7 +60,7 @@ if [[ $(command -v jq) ]]; then
 
             (cd "$path" && npm install --prefer-offline)
         fi
-    done < <(jq -c '.[]' "var/plugins.json")
+    done
 
     for basePath in "${basePaths[@]}"; do
         if [[ -r "${basePath}/package.json" ]]; then


### PR DESCRIPTION
This pull request removes the process substitution from while loops as that leads to problems in shared hosting environments where the user does not have access to `/dev` or `/proc`. Piping into the while loop is functionally identical in this case and does not lead to these problems.

Fixes #216