### PR TITLE
feat(shopware/paas-meta): set messenger transport env var defaults

### DIFF
--- a/shopware/paas-meta/6.7/manifest.json
+++ b/shopware/paas-meta/6.7/manifest.json
@@ -13,7 +13,7 @@
         "default_redis_port": "6379",
         "env(CACHE_URL)": "redis://localhost",
         "env(MESSENGER_TRANSPORT_DSN_PREFIX)": "doctrine://default?auto_setup=false&queue_name=",
-        "env(MESSENGER_TRANSPORT_DSN)": "%env(MESSENGER_TRANSPORT_DSN_PREFIX)%messages%",
-        "env(MESSENGER_TRANSPORT_LOW_PRIORITY_DSN)": "%env(MESSENGER_TRANSPORT_DSN_PREFIX)%low_priority%"
+        "env(MESSENGER_TRANSPORT_DSN)": "%env(MESSENGER_TRANSPORT_DSN_PREFIX)%messages",
+        "env(MESSENGER_TRANSPORT_LOW_PRIORITY_DSN)": "%env(MESSENGER_TRANSPORT_DSN_PREFIX)%low_priority"
     }
 }


### PR DESCRIPTION
Set `MESSENGER_TRANSPORT_DSN` and `MESSENGER_TRANSPORT_LOW_PRIORITY_DSN` based on the new `MESSENGER_TRANSPORT_DSN_PREFIX` which is set by shopware/paas-meta.

See: https://github.com/shopware/paas-meta/pull/15

Resolves: https://github.com/shopware/paas-meta/issues/14