### PR TITLE
fix: Update composer to ensure safe version

### DIFF
--- a/shopware/paas-meta/6.4/.platform/applications.yaml
+++ b/shopware/paas-meta/6.4/.platform/applications.yaml
@@ -4,7 +4,7 @@
         flavor: composer
     dependencies:
         php:
-            composer/composer: "2.5.*"
+            composer/composer: "^2.9.3"
     variables:
         env:
             # Tell Shopware to always install in production-mode.

--- a/shopware/paas-meta/6.5/.platform/applications.yaml
+++ b/shopware/paas-meta/6.5/.platform/applications.yaml
@@ -4,7 +4,7 @@
         flavor: none
     dependencies:
         php:
-            composer/composer: "2.8"
+            composer/composer: "^2.9.3"
     variables:
         env:
             APP_ENV: prod

--- a/shopware/paas-meta/6.6/.platform/applications.yaml
+++ b/shopware/paas-meta/6.6/.platform/applications.yaml
@@ -4,7 +4,7 @@
         flavor: none
     dependencies:
         php:
-            composer/composer: "2.8"
+            composer/composer: "^2.9.3"
     variables:
         env:
             APP_ENV: prod

--- a/shopware/paas-meta/6.7/.platform/applications.yaml
+++ b/shopware/paas-meta/6.7/.platform/applications.yaml
@@ -4,7 +4,7 @@
         flavor: none
     dependencies:
         php:
-            composer/composer: "2.8"
+            composer/composer: "^2.9.3"
     variables:
         env:
             APP_ENV: prod


### PR DESCRIPTION
### 1. Why is this change necessary?

composer had a security release last week https://github.com/composer/composer/releases/tag/2.9.3

### 2. What does this change do, exactly?

Ensure, that we use a safe version