### PR TITLE
feat: add messenger transport configuration for Redis

### DIFF
--- a/shopware/k8s-meta/1.0/config/packages/operator.yaml
+++ b/shopware/k8s-meta/1.0/config/packages/operator.yaml
@@ -16,6 +16,8 @@ parameters:
     env(PHP_SESSION_SAVE_PATH): "tcp://127.0.0.1:6379"
     env(K8S_REDIS_SESSION_DSN): "redis://%env(string:key:host:url:PHP_SESSION_SAVE_PATH)%:%env(string:key:port:url:PHP_SESSION_SAVE_PATH)%/%env(string:key:path:url:PHP_SESSION_SAVE_PATH)%"
     env(K8S_REDIS_APP_DSN): "redis://%env(K8S_CACHE_HOST)%:%env(K8S_CACHE_PORT)%/%env(K8S_CACHE_INDEX)%"
+    env(MESSENGER_TRANSPORT_DSN): "redis://127.0.0.1:6379/messages/symfony/?auto_setup=true&serializer=1&stream_max_entries=0&dbindex=0"
+    env(MESSENGER_CONSUMER_NAME): "shopware-worker"
 
 shopware:
     api:
@@ -73,6 +75,12 @@ elasticsearch:
 
 
 framework:
+    messenger:
+        transports:
+            async:
+                dsn: "%env(MESSENGER_TRANSPORT_DSN)%"
+                options:
+                    consumer: '%env(MESSENGER_CONSUMER_NAME)%'
     session:
         handler_id: Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler
     cache:

--- a/shopware/k8s-meta/2.0/config/packages/operator.yaml
+++ b/shopware/k8s-meta/2.0/config/packages/operator.yaml
@@ -16,6 +16,8 @@ parameters:
     env(PHP_SESSION_SAVE_PATH): "tcp://127.0.0.1:6379"
     env(K8S_REDIS_SESSION_DSN): "redis://%env(string:key:host:url:PHP_SESSION_SAVE_PATH)%:%env(string:key:port:url:PHP_SESSION_SAVE_PATH)%/%env(string:key:path:url:PHP_SESSION_SAVE_PATH)%"
     env(K8S_REDIS_APP_DSN): "redis://%env(K8S_CACHE_HOST)%:%env(K8S_CACHE_PORT)%/%env(K8S_CACHE_INDEX)%"
+    env(MESSENGER_TRANSPORT_DSN): "redis://127.0.0.1:6379/messages/symfony/?auto_setup=true&serializer=1&stream_max_entries=0&dbindex=0"
+    env(MESSENGER_CONSUMER_NAME): "shopware-worker"
 
 shopware:
     admin_worker:
@@ -68,6 +70,12 @@ elasticsearch:
         number_of_shards: "%env(int:K8S_ES_NUMBER_OF_SHARDS)%"
 
 framework:
+    messenger:
+        transports:
+            async:
+                dsn: "%env(MESSENGER_TRANSPORT_DSN)%"
+                options:
+                    consumer: '%env(MESSENGER_CONSUMER_NAME)%'
     cache:
         app: cache.adapter.redis_tag_aware
         default_redis_provider: '%env(K8S_REDIS_APP_DSN)%'


### PR DESCRIPTION
This pull request introduces configuration changes to enable Symfony Messenger with Redis transport in both the `1.0` and `2.0` operator YAML files for Shopware. The main updates are the addition of environment variables and framework configuration to support asynchronous message handling.

Configuration for Symfony Messenger:

* Added `MESSENGER_TRANSPORT_DSN` and `MESSENGER_CONSUMER_NAME` environment variables under `parameters:` to both `shopware/k8s-meta/1.0/config/packages/operator.yaml` and `shopware/k8s-meta/2.0/config/packages/operator.yaml`, specifying Redis connection details and consumer name. [[1]](diffhunk://#diff-a019c3b6407301585db50547ad2fe0c9239bfd700e5c877c66a39cd331c9ff8aR19-R20) [[2]](diffhunk://#diff-80fc77609e6816bcac067e19995ec2bab7d5f8b03cdfbf7c3a3488bbb1282c0dR19-R20)
* Introduced `messenger` configuration under `framework:` in both operator YAML files, defining the `async` transport with Redis DSN and consumer options, enabling asynchronous message processing. [[1]](diffhunk://#diff-a019c3b6407301585db50547ad2fe0c9239bfd700e5c877c66a39cd331c9ff8aR78-R83) [[2]](diffhunk://#diff-80fc77609e6816bcac067e19995ec2bab7d5f8b03cdfbf7c3a3488bbb1282c0dR73-R78)