### PR TITLE
Remove default APP_ENV value from manifest.json

### DIFF
--- a/shopware/docker-dev/0.1/manifest.json
+++ b/shopware/docker-dev/0.1/manifest.json
@@ -14,7 +14,6 @@
                 "  env_file:",
                 "    - .env.local",
                 "  environment:",
-                "    APP_ENV: ${APP_ENV-dev}",
                 "    HOST: 0.0.0.0",
                 "    DATABASE_URL: mysql://root:root@database/shopware",
                 "    MAILER_DSN: smtp://mailer:1025",


### PR DESCRIPTION
Is fixed here https://github.com/shopware/docker/pull/194
