### PR TITLE
Move Logs to a local mount to avoid performance issues

### DIFF
--- a/shopware/paas-meta/6.6/.platform/applications.yaml
+++ b/shopware/paas-meta/6.6/.platform/applications.yaml
@@ -17,6 +17,8 @@
             SHOPWARE_SKIP_WEBINSTALLER: 1
             # Performance optimization
             COMPOSER_ROOT_VERSION: 1.0.0
+            # Set the log directory to a path outside of the shared mount to avoid performance issues
+            APP_LOG_DIR: /app/localLog
         php:
             upload_max_filesize: 32M
             post_max_size: 32M
@@ -143,6 +145,9 @@
         "/localCache":
             source: local
             source_path: "localCache"
+        "/localLog":
+            source: local
+            source_path: "localLog"
 
     # The configuration of app when it is exposed to the web.
     web:

--- a/shopware/paas-meta/6.7/.platform/applications.yaml
+++ b/shopware/paas-meta/6.7/.platform/applications.yaml
@@ -17,6 +17,8 @@
             SHOPWARE_SKIP_WEBINSTALLER: 1
             # Performance optimization
             COMPOSER_ROOT_VERSION: 1.0.0
+            # Set the log directory to a path outside of the shared mount to avoid performance issues
+            APP_LOG_DIR: /app/localLog
         php:
             upload_max_filesize: 32M
             post_max_size: 32M
@@ -143,6 +145,9 @@
         "/localCache":
             source: local
             source_path: "localCache"
+        "/localLog":
+            source: local
+            source_path: "localLog"
 
     # The configuration of app when it is exposed to the web.
     web:


### PR DESCRIPTION
By default logs are written to `./var/log`.
`./var` needs to be on a shared mount as some files needs to be shared between instances and/or with workers. 
But logs don't need to be shared and it can lead to performance issue.

Starting with Showpare 6.6.8.0, logs can be moved to another place: https://developer.shopware.com/docs/guides/hosting/configurations/shopware/environment-variables.html.