### PR TITLE
Use environment variable in docker monolog config

### DIFF
--- a/shopware/docker/0.2/config/packages/prod/monolog.yaml
+++ b/shopware/docker/0.2/config/packages/prod/monolog.yaml
@@ -1,19 +1,21 @@
+parameters:
+  env(MONOLOG_LOG_LEVEL): "error"
 monolog:
     handlers:
         main:
             type: fingers_crossed
-            action_level: error
+            action_level: "%env(MONOLOG_LOG_LEVEL)%"
             handler: nested
             excluded_http_codes: [404, 405]
             buffer_size: 50
         nested:
             type: stream
             path: php://stderr
-            level: error
+            level: "%env(MONOLOG_LOG_LEVEL)%"
             formatter: monolog.formatter.json
         console:
             type: console
             process_psr_3_messages: false
             channels: ["!event", "!doctrine"]
         business_event_handler_buffer:
-            level: error
+            level: "%env(MONOLOG_LOG_LEVEL)%"

--- a/shopware/docker/0.3/config/packages/prod/monolog.yaml
+++ b/shopware/docker/0.3/config/packages/prod/monolog.yaml
@@ -1,19 +1,21 @@
+parameters:
+  env(MONOLOG_LOG_LEVEL): "error"
 monolog:
     handlers:
         main:
             type: fingers_crossed
-            action_level: error
+            action_level: "%env(MONOLOG_LOG_LEVEL)%"
             handler: nested
             excluded_http_codes: [404, 405]
             buffer_size: 50
         nested:
             type: stream
             path: php://stderr
-            level: error
+            level: "%env(MONOLOG_LOG_LEVEL)%"
             formatter: monolog.formatter.json
         console:
             type: console
             process_psr_3_messages: false
             channels: ["!event", "!doctrine"]
         business_event_handler_buffer:
-            level: error
+            level: "%env(MONOLOG_LOG_LEVEL)%"


### PR DESCRIPTION
This pull request updates the logging configuration in the production environment for both the `shopware/docker/0.2` and `shopware/docker/0.3` setups. The main change is to make the log level configurable through an environment variable, allowing for more flexibility in controlling log verbosity without modifying code.

Logging configuration improvements:

* Added a `MONOLOG_LOG_LEVEL` environment variable and updated the `monolog.yaml` files to use this variable for the log level and action level settings, replacing the previous hardcoded `"error"` value.