### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/callable-qa.yml
+++ b/.github/workflows/callable-qa.yml
@@ -21,7 +21,7 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               id: checkout
               with:
                 fetch-depth: 0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,7 +59,7 @@ jobs:
                     php-version: ${{ matrix.php }}
 
             - name: Setup Node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ matrix.node }}
 

--- a/.github/workflows/platform-sync.yml
+++ b/.github/workflows/platform-sync.yml
@@ -19,13 +19,13 @@ jobs:
         concurrency: platform-sync-${{ github.ref }}
         name: Sync files for shopware/platform package
         steps:
-            - uses: octo-sts/action@main
+            - uses: octo-sts/action@v1.0.0
               id: octo-sts
               with:
                 scope: shopware/recipes
                 identity: PlatformSync
             - name: Clone
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                 token: ${{ steps.octo-sts.outputs.token }}
 
@@ -36,6 +36,6 @@ jobs:
               run: git add .
 
             - name: Update shopware/platform package
-              uses: stefanzweifel/git-auto-commit-action@v4
+              uses: stefanzweifel/git-auto-commit-action@v7
               with:
                 commit_message: 'chore: update shopware/platform package'


### PR DESCRIPTION
## Summary

- Update `actions/checkout` from v4 to v6
- Update `actions/setup-node` from v4 to v6
- Update `octo-sts/action` from main to v1.0.0
- Update `stefanzweifel/git-auto-commit-action` from v4 to v7

## Test plan

- [ ] Verify CI workflows still pass