### PR TITLE
feat: Disable backend data collection via symfony config

### DIFF
--- a/shopware/k8s-meta/1.0/config/packages/operator.yaml
+++ b/shopware/k8s-meta/1.0/config/packages/operator.yaml
@@ -67,6 +67,10 @@ shopware:
                 root: '%kernel.project_dir%/public'
     cdn:
         url: "%env(K8S_FILESYSTEM_PUBLIC_URL)%"
+    usage_data:
+        collection_enabled: false
+        gateway:
+            dispatch_enabled: false
 
 elasticsearch:
     index_settings:

--- a/shopware/k8s-meta/1.0/config/packages/operator.yaml
+++ b/shopware/k8s-meta/1.0/config/packages/operator.yaml
@@ -68,7 +68,6 @@ shopware:
     cdn:
         url: "%env(K8S_FILESYSTEM_PUBLIC_URL)%"
     usage_data:
-        collection_enabled: false
         gateway:
             dispatch_enabled: false
 

--- a/shopware/k8s-meta/2.0/config/packages/operator.yaml
+++ b/shopware/k8s-meta/2.0/config/packages/operator.yaml
@@ -63,6 +63,10 @@ shopware:
         connections:
             session:
                 dsn: '%env(K8S_REDIS_SESSION_DSN)%'
+    usage_data:
+        collection_enabled: false
+        gateway:
+            dispatch_enabled: false
 
 elasticsearch:
     index_settings:


### PR DESCRIPTION
We are not allowed to collect data from PaaS shops. Right now, we disable it by revoking the consent when shopware is deployed. This is insufficient because the user can just accept data collection in the Admin again. Especially with the next Shopware update, a modal will appear to decline/accept data collection.

With this change, we disable the process of collecting data in the backend, reducing the load on the server.

Notice that this is just a best effort approach, and the shop owner can still override the Symfony config.