### PR TITLE
fix: Adds missing bits to use Redis as session handler.

### DIFF
--- a/shopware/k8s-meta/2.0/config/packages/operator.yaml
+++ b/shopware/k8s-meta/2.0/config/packages/operator.yaml
@@ -96,5 +96,5 @@ services:
             - '%env(K8S_REDIS_SESSION_DSN)%'
     Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler:
         arguments:
-            - '@shopware.redis.connection.session'
+            - '@Redis'
             - { prefix: 'sess_' }

--- a/shopware/k8s-meta/2.0/config/packages/operator.yaml
+++ b/shopware/k8s-meta/2.0/config/packages/operator.yaml
@@ -74,6 +74,8 @@ elasticsearch:
         number_of_shards: "%env(int:K8S_ES_NUMBER_OF_SHARDS)%"
 
 framework:
+    session:
+        handler_id: Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler
     messenger:
         transports:
             async:
@@ -87,6 +89,11 @@ framework:
         message_bus: 'messenger.default_bus'
 
 services:
+    Redis:
+        class: Redis
+        factory: ['Symfony\Component\Cache\Adapter\RedisAdapter', 'createConnection']
+        arguments:
+            - '%env(K8S_REDIS_SESSION_DSN)%'
     Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler:
         arguments:
             - '@shopware.redis.connection.session'


### PR DESCRIPTION
This pull request updates the session handling configuration to use Redis for session storage in the `operator.yaml` file. The changes introduce a Redis service definition and configure the session handler to use `RedisSessionHandler`.

Session handling improvements:

* Configured the session handler to use `Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler`, enabling Redis-backed session storage.

Redis service setup:

* Added a `Redis` service definition using the `Symfony\Component\Cache\Adapter\RedisAdapter::createConnection` factory with the session DSN from the environment variable `%env(K8S_REDIS_SESSION_DSN)%`.