### PR TITLE
feat: parallelize theme:compile in storefront build recipe

### DIFF
--- a/shopware/storefront/6.6/bin/build-storefront.sh
+++ b/shopware/storefront/6.6/bin/build-storefront.sh
@@ -63,7 +63,54 @@ npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --prefer-offl
 node "${STOREFRONT_ROOT}"/Resources/app/storefront/copy-to-vendor.js
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run production
 [[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install
-[[ ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]] || "${BIN_TOOL}" theme:compile --active-only
+if [[ -z ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]]; then
+    if ! command -v jq >/dev/null 2>&1; then
+        # No jq available, compile sequentially
+        "${BIN_TOOL}" theme:compile --active-only --sync
+    else
+        # Parallelize theme:compile across sales channels.
+        # First channel compiles with assets (writes theme/<themeId>/ serially to avoid races).
+        # Remaining channels run in parallel with --keep-assets (CSS only, no shared write path).
+        channels=$("${BIN_TOOL}" sales-channel:list --output=json \
+            | jq -r '[.[] | select(.active=="active")] | .[] | .id + "|" + .name')
+
+        if [[ -z "$channels" ]]; then
+            echo "No active sales channels, skipping theme compile."
+        else
+            first_channel=$(echo "$channels" | head -1)
+            rest_channels=$(echo "$channels" | tail -n +2)
+            rest_count=$(echo -n "$rest_channels" | grep -c . 2>/dev/null || true)
+            cpu_count=$(sysctl -n hw.logicalcpu 2>/dev/null || nproc 2>/dev/null || echo 4)
+            workers="${THEME_COMPILE_WORKERS:-$(( rest_count < cpu_count ? rest_count : cpu_count ))}"
+            [[ $workers -lt 1 ]] && workers=1
+
+            compile_channel() {
+                local pair="$1"; shift
+                local id="${pair%%|*}"
+                local name="${pair##*|}"
+                local output exit_code
+                output=$("$BIN_TOOL" theme:compile --only "$id" --sync "$@" 2>&1); exit_code=$?
+                if [[ $exit_code -eq 0 ]]; then
+                    printf "  ok  %s\n" "$name"
+                else
+                    printf "  FAIL  %s\n%s\n" "$name" "$output"
+                    return $exit_code
+                fi
+            }
+            export -f compile_channel
+            export BIN_TOOL
+
+            total=$(echo "$channels" | wc -l | tr -d ' ')
+            echo "Compiling themes: ${total} sales channel(s), ${workers} parallel worker(s)"
+
+            compile_channel "$first_channel"
+            if [[ -n "$rest_channels" ]]; then
+                echo "$rest_channels" \
+                    | xargs -P"$workers" -I{} bash -c 'compile_channel "$1" --keep-assets' _ {}
+            fi
+        fi
+    fi
+fi
 
 if ! [ "${1:-default}" = "--keep-cache" ]; then
     "${BIN_TOOL}" cache:clear

--- a/shopware/storefront/6.6/bin/build-storefront.sh
+++ b/shopware/storefront/6.6/bin/build-storefront.sh
@@ -27,6 +27,16 @@ if [[ ${CI:-""} ]]; then
     fi
 fi
 
+keep_cache=0
+parallel=0
+for arg in "$@"; do
+    case "$arg" in
+        --keep-cache) keep_cache=1 ;;
+        --parallel)   parallel=1 ;;
+    esac
+done
+[[ ${SHOPWARE_THEME_COMPILE_PARALLEL:-""} ]] && parallel=1
+
 # build storefront
 [[ ${SHOPWARE_SKIP_BUNDLE_DUMP:-""} ]] || "${BIN_TOOL}" bundle:dump
 [[ ${SHOPWARE_SKIP_FEATURE_DUMP:-""} ]] || "${BIN_TOOL}" feature:dump
@@ -64,10 +74,7 @@ node "${STOREFRONT_ROOT}"/Resources/app/storefront/copy-to-vendor.js
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run production
 [[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install
 if [[ -z ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]]; then
-    if ! command -v jq >/dev/null 2>&1; then
-        # No jq available, compile sequentially
-        "${BIN_TOOL}" theme:compile --active-only --sync
-    else
+    if [[ $parallel -eq 1 ]] && command -v jq >/dev/null 2>&1; then
         # Parallelize theme:compile across sales channels.
         # First channel compiles with assets (writes theme/<themeId>/ serially to avoid races).
         # Remaining channels run in parallel with --keep-assets (CSS only, no shared write path).
@@ -81,7 +88,7 @@ if [[ -z ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]]; then
             rest_channels=$(echo "$channels" | tail -n +2)
             rest_count=$(echo -n "$rest_channels" | grep -c . 2>/dev/null || true)
             cpu_count=$(sysctl -n hw.logicalcpu 2>/dev/null || nproc 2>/dev/null || echo 4)
-            workers="${THEME_COMPILE_WORKERS:-$(( rest_count < cpu_count ? rest_count : cpu_count ))}"
+            workers="${SHOPWARE_THEME_COMPILE_WORKERS:-$(( rest_count < cpu_count ? rest_count : cpu_count ))}"
             [[ $workers -lt 1 ]] && workers=1
 
             compile_channel() {
@@ -110,9 +117,11 @@ if [[ -z ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]]; then
                     | xargs -P"$workers" -I{} bash -c 'compile_channel "$1" --keep-assets' _ {}
             fi
         fi
+    else
+        "${BIN_TOOL}" theme:compile --active-only --sync
     fi
 fi
 
-if ! [ "${1:-default}" = "--keep-cache" ]; then
+if [[ $keep_cache -eq 0 ]]; then
     "${BIN_TOOL}" cache:clear
 fi

--- a/shopware/storefront/6.6/bin/build-storefront.sh
+++ b/shopware/storefront/6.6/bin/build-storefront.sh
@@ -105,6 +105,7 @@ if [[ -z ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]]; then
 
             compile_channel "$first_channel"
             if [[ -n "$rest_channels" ]]; then
+                # shellcheck disable=SC2016
                 echo "$rest_channels" \
                     | xargs -P"$workers" -I{} bash -c 'compile_channel "$1" --keep-assets' _ {}
             fi

--- a/shopware/storefront/6.7/bin/build-storefront.sh
+++ b/shopware/storefront/6.7/bin/build-storefront.sh
@@ -27,6 +27,16 @@ if [[ ${CI:-""} ]]; then
     fi
 fi
 
+keep_cache=0
+parallel=0
+for arg in "$@"; do
+    case "$arg" in
+        --keep-cache) keep_cache=1 ;;
+        --parallel)   parallel=1 ;;
+    esac
+done
+[[ ${SHOPWARE_THEME_COMPILE_PARALLEL:-""} ]] && parallel=1
+
 # build storefront
 [[ ${SHOPWARE_SKIP_BUNDLE_DUMP:-""} ]] || "${BIN_TOOL}" bundle:dump
 [[ ${SHOPWARE_SKIP_FEATURE_DUMP:-""} ]] || "${BIN_TOOL}" feature:dump
@@ -87,10 +97,7 @@ node "${STOREFRONT_ROOT}"/Resources/app/storefront/copy-to-vendor.js
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run production
 [[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install
 if [[ -z ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]]; then
-    if ! command -v jq >/dev/null 2>&1; then
-        # No jq available, compile sequentially
-        "${BIN_TOOL}" theme:compile --active-only --sync
-    else
+    if [[ $parallel -eq 1 ]] && command -v jq >/dev/null 2>&1; then
         # Parallelize theme:compile across sales channels.
         # First channel compiles with assets (writes theme/<themeId>/ serially to avoid races).
         # Remaining channels run in parallel with --keep-assets (CSS only, no shared write path).
@@ -104,7 +111,7 @@ if [[ -z ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]]; then
             rest_channels=$(echo "$channels" | tail -n +2)
             rest_count=$(echo -n "$rest_channels" | grep -c . 2>/dev/null || true)
             cpu_count=$(sysctl -n hw.logicalcpu 2>/dev/null || nproc 2>/dev/null || echo 4)
-            workers="${THEME_COMPILE_WORKERS:-$(( rest_count < cpu_count ? rest_count : cpu_count ))}"
+            workers="${SHOPWARE_THEME_COMPILE_WORKERS:-$(( rest_count < cpu_count ? rest_count : cpu_count ))}"
             [[ $workers -lt 1 ]] && workers=1
 
             compile_channel() {
@@ -133,9 +140,11 @@ if [[ -z ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]]; then
                     | xargs -P"$workers" -I{} bash -c 'compile_channel "$1" --keep-assets' _ {}
             fi
         fi
+    else
+        "${BIN_TOOL}" theme:compile --active-only --sync
     fi
 fi
 
-if ! [ "${1:-default}" = "--keep-cache" ]; then
+if [[ $keep_cache -eq 0 ]]; then
     "${BIN_TOOL}" cache:clear
 fi

--- a/shopware/storefront/6.7/bin/build-storefront.sh
+++ b/shopware/storefront/6.7/bin/build-storefront.sh
@@ -128,6 +128,7 @@ if [[ -z ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]]; then
 
             compile_channel "$first_channel"
             if [[ -n "$rest_channels" ]]; then
+                # shellcheck disable=SC2016
                 echo "$rest_channels" \
                     | xargs -P"$workers" -I{} bash -c 'compile_channel "$1" --keep-assets' _ {}
             fi

--- a/shopware/storefront/6.7/bin/build-storefront.sh
+++ b/shopware/storefront/6.7/bin/build-storefront.sh
@@ -86,7 +86,54 @@ npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront install --prefer-offl
 node "${STOREFRONT_ROOT}"/Resources/app/storefront/copy-to-vendor.js
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run production
 [[ ${SHOPWARE_SKIP_ASSET_COPY:-""} ]] ||"${BIN_TOOL}" assets:install
-[[ ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]] || "${BIN_TOOL}" theme:compile --active-only
+if [[ -z ${SHOPWARE_SKIP_THEME_COMPILE:-""} ]]; then
+    if ! command -v jq >/dev/null 2>&1; then
+        # No jq available, compile sequentially
+        "${BIN_TOOL}" theme:compile --active-only --sync
+    else
+        # Parallelize theme:compile across sales channels.
+        # First channel compiles with assets (writes theme/<themeId>/ serially to avoid races).
+        # Remaining channels run in parallel with --keep-assets (CSS only, no shared write path).
+        channels=$("${BIN_TOOL}" sales-channel:list --output=json \
+            | jq -r '[.[] | select(.active=="active")] | .[] | .id + "|" + .name')
+
+        if [[ -z "$channels" ]]; then
+            echo "No active sales channels, skipping theme compile."
+        else
+            first_channel=$(echo "$channels" | head -1)
+            rest_channels=$(echo "$channels" | tail -n +2)
+            rest_count=$(echo -n "$rest_channels" | grep -c . 2>/dev/null || true)
+            cpu_count=$(sysctl -n hw.logicalcpu 2>/dev/null || nproc 2>/dev/null || echo 4)
+            workers="${THEME_COMPILE_WORKERS:-$(( rest_count < cpu_count ? rest_count : cpu_count ))}"
+            [[ $workers -lt 1 ]] && workers=1
+
+            compile_channel() {
+                local pair="$1"; shift
+                local id="${pair%%|*}"
+                local name="${pair##*|}"
+                local output exit_code
+                output=$("$BIN_TOOL" theme:compile --only "$id" --sync "$@" 2>&1); exit_code=$?
+                if [[ $exit_code -eq 0 ]]; then
+                    printf "  ok  %s\n" "$name"
+                else
+                    printf "  FAIL  %s\n%s\n" "$name" "$output"
+                    return $exit_code
+                fi
+            }
+            export -f compile_channel
+            export BIN_TOOL
+
+            total=$(echo "$channels" | wc -l | tr -d ' ')
+            echo "Compiling themes: ${total} sales channel(s), ${workers} parallel worker(s)"
+
+            compile_channel "$first_channel"
+            if [[ -n "$rest_channels" ]]; then
+                echo "$rest_channels" \
+                    | xargs -P"$workers" -I{} bash -c 'compile_channel "$1" --keep-assets' _ {}
+            fi
+        fi
+    fi
+fi
 
 if ! [ "${1:-default}" = "--keep-cache" ]; then
     "${BIN_TOOL}" cache:clear


### PR DESCRIPTION
## Motivation

Compiling themes for many active sales channels is the dominant bottleneck in sequential storefront builds. Each compile adds ~6–15 s of Node + SCSS overhead; with 10+ channels this compounds to minutes in CI.

## Opt-in

The parallel path is **opt-in**. Default behavior is unchanged (`theme:compile --active-only --sync`).

Enable via flag:
```sh
bin/build-storefront.sh --parallel
```
or via environment variable (useful in CI pipelines where passing flags through is awkward):
```sh
SHOPWARE_THEME_COMPILE_PARALLEL=1 bin/build-storefront.sh
```

Worker count defaults to the number of logical CPUs; override with `SHOPWARE_THEME_COMPILE_WORKERS`:
```sh
SHOPWARE_THEME_COMPILE_WORKERS=4 bin/build-storefront.sh --parallel
```

## Mechanism

The first sales channel is compiled serially so that shared theme assets (`theme/<themeId>/`) are written without race conditions. All remaining channels then compile in parallel with `--keep-assets`, which only writes the per-channel CSS path (`theme/<themePrefix>/css/all.css`) and has no shared write target.

This continues the direction of the `--sync` option added in 6.6.1.0 ([changelog](https://github.com/shopware/shopware/blob/trunk/changelog/release-6-6-1-0/2024-04-02-add-sync-theme-compile-cli-option.md)): `--sync` moved theme compilation into the foreground build process; this change parallelizes that foreground work at the process level.

## Details

- Uses only existing CLI flags (`--sync`, `--keep-assets`, `--only`) — no core changes required.
- Falls back to standard sequential `theme:compile --active-only --sync` when `--parallel` is not set or `jq` is unavailable.
- Applies to both 6.6 and 6.7 recipe variants (identical change in each).

## Known limitation

In setups where different sales channels use different themes, only the first channel's theme assets are refreshed. This is acceptable for the typical build scenario (fresh deployment, single shared theme). Use `SHOPWARE_SKIP_THEME_COMPILE=1` plus a manual `theme:compile` call for heterogeneous-theme setups.