### PR TITLE
Add deprecation warnings to legacy build and watch scripts

### DIFF
--- a/shopware/platform/6.6/bin/build-administration.sh
+++ b/shopware/platform/6.6/bin/build-administration.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+echo "[DEPRECATION] bin/build-administration.sh is deprecated as of Shopware 6.8 and will be removed in a future version."
+echo "[DEPRECATION] Please use shopware-cli instead: shopware-cli project admin-build"
+echo "[DEPRECATION] See https://developer.shopware.com/docs/products/cli/ for installation and usage."
+
 unset CDPATH
 CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 

--- a/shopware/platform/6.6/bin/build-storefront.sh
+++ b/shopware/platform/6.6/bin/build-storefront.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+echo "[DEPRECATION] bin/build-storefront.sh is deprecated as of Shopware 6.8 and will be removed in a future version."
+echo "[DEPRECATION] Please use shopware-cli instead: shopware-cli project storefront-build"
+echo "[DEPRECATION] See https://developer.shopware.com/docs/products/cli/ for installation and usage."
+
 unset CDPATH
 CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 

--- a/shopware/platform/6.6/bin/watch-administration.sh
+++ b/shopware/platform/6.6/bin/watch-administration.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+echo "[DEPRECATION] bin/watch-administration.sh is deprecated as of Shopware 6.8 and will be removed in a future version."
+echo "[DEPRECATION] Please use shopware-cli instead: shopware-cli project admin-watch"
+echo "[DEPRECATION] See https://developer.shopware.com/docs/products/cli/ for installation and usage."
+
 CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"

--- a/shopware/platform/6.6/bin/watch-storefront.sh
+++ b/shopware/platform/6.6/bin/watch-storefront.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+echo "[DEPRECATION] bin/watch-storefront.sh is deprecated as of Shopware 6.8 and will be removed in a future version."
+echo "[DEPRECATION] Please use shopware-cli instead: shopware-cli project storefront-watch"
+echo "[DEPRECATION] See https://developer.shopware.com/docs/products/cli/ for installation and usage."
+
 CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"

--- a/shopware/platform/6.7/bin/build-administration.sh
+++ b/shopware/platform/6.7/bin/build-administration.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # shellcheck source-path=SCRIPTDIR
 
+echo "[DEPRECATION] bin/build-administration.sh is deprecated as of Shopware 6.8 and will be removed in a future version."
+echo "[DEPRECATION] Please use shopware-cli instead: shopware-cli project admin-build"
+echo "[DEPRECATION] See https://developer.shopware.com/docs/products/cli/ for installation and usage."
+
 unset CDPATH
 CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 

--- a/shopware/platform/6.7/bin/build-storefront.sh
+++ b/shopware/platform/6.7/bin/build-storefront.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+echo "[DEPRECATION] bin/build-storefront.sh is deprecated as of Shopware 6.8 and will be removed in a future version."
+echo "[DEPRECATION] Please use shopware-cli instead: shopware-cli project storefront-build"
+echo "[DEPRECATION] See https://developer.shopware.com/docs/products/cli/ for installation and usage."
+
 unset CDPATH
 CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 

--- a/shopware/platform/6.7/bin/watch-administration.sh
+++ b/shopware/platform/6.7/bin/watch-administration.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+echo "[DEPRECATION] bin/watch-administration.sh is deprecated as of Shopware 6.8 and will be removed in a future version."
+echo "[DEPRECATION] Please use shopware-cli instead: shopware-cli project admin-watch"
+echo "[DEPRECATION] See https://developer.shopware.com/docs/products/cli/ for installation and usage."
+
 CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"

--- a/shopware/platform/6.7/bin/watch-storefront.sh
+++ b/shopware/platform/6.7/bin/watch-storefront.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+echo "[DEPRECATION] bin/watch-storefront.sh is deprecated as of Shopware 6.8 and will be removed in a future version."
+echo "[DEPRECATION] Please use shopware-cli instead: shopware-cli project storefront-watch"
+echo "[DEPRECATION] See https://developer.shopware.com/docs/products/cli/ for installation and usage."
+
 CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"


### PR DESCRIPTION
## Summary
This PR adds deprecation warnings to the legacy build and watch shell scripts across Shopware 6.6 and 6.7, informing users that these scripts will be removed in Shopware 6.8 and directing them to use `shopware-cli` instead.

## Changes
- Added deprecation notices to four script types in both 6.6 and 6.7 branches:
  - `bin/build-administration.sh` - directs to `shopware-cli project admin-build`
  - `bin/build-storefront.sh` - directs to `shopware-cli project storefront-build`
  - `bin/watch-administration.sh` - directs to `shopware-cli project admin-watch`
  - `bin/watch-storefront.sh` - directs to `shopware-cli project storefront-watch`
- Each script now outputs three deprecation messages at the start of execution:
  - Notification that the script is deprecated as of Shopware 6.8
  - Recommended replacement command using `shopware-cli`
  - Link to CLI documentation for installation and usage

## Implementation Details
- Deprecation messages are printed to stdout using `echo` statements
- Messages are prefixed with `[DEPRECATION]` for easy identification
- Scripts continue to function normally after displaying warnings
- Changes are consistent across all affected scripts and versions

https://claude.ai/code/session_01GjfCpDDmUmZ84wPKwwqWFz