### PR TITLE
fix: forward installer handover parameters in the 6.7 recipe

### DIFF
--- a/shopware/core/6.7/public/index.php
+++ b/shopware/core/6.7/public/index.php
@@ -2,6 +2,7 @@
 
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\ComposerPluginLoader;
+use Shopware\Core\Installer\Helper\InstallerRedirectHelper;
 use Shopware\Core\Installer\InstallerKernel;
 use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
 
@@ -21,7 +22,14 @@ return function (array $context) {
         $baseURL = rtrim($baseURL, '/');
 
         if (strpos($_SERVER['REQUEST_URI'], '/installer') === false) {
-            header('Location: ' . $baseURL . '/installer');
+            // InstallerRedirectHelper was introduced in 6.7.5.0; older 6.7 patch releases
+            // ship no such class, so forward the sanitised query only when it is available.
+            $query = match (true) {
+                class_exists(InstallerRedirectHelper::class) => (new InstallerRedirectHelper($_SERVER))->buildQueryString(),
+                default => '',
+            };
+
+            header('Location: ' . $baseURL . '/installer' . $query);
             exit;
         }
     }


### PR DESCRIPTION
The web installer continues the guided setup by redirecting to the core `/installer` route with the chosen language and the current step as query parameters. The `6.7` recipe's `public/index.php` dropped that query on the redirect, so users following the documented server setup lost their language and started the setup over, because the handover parameters never reached core.

The `6.7` front controller now forwards the sanitised query string produced by `InstallerRedirectHelper` when it redirects to `/installer`. That helper only exists from 6.7.5.0 onwards, so the call is guarded by `class_exists()`: older 6.7 patch releases redirect without a query, exactly as before, while 6.7.5.0 and newer gain the full handover. A single `6.7` recipe therefore covers the whole 6.7 line without a dedicated version folder.

Without these recipes, https://github.com/shopware/shopware/commit/a00e9a8aeb4def0ab00bd60f586cd5ff9ac11d22 and https://github.com/shopware/web-installer/commit/91333c0e90bdbea4da70d6a3a0d9eb262e35dc73 won't properly provide a unified experience with one single stepper, as the setup won't take the parameters passed by the web-installer