### PR TITLE
Change deprecated `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` to `PUPPETEER_SKIP_DOWNLOAD`

### DIFF
--- a/shopware/administration/6.4/bin/build-administration.sh
+++ b/shopware/administration/6.4/bin/build-administration.sh
@@ -21,6 +21,7 @@ set +o allexport
 set -euo pipefail
 
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+export PUPPETEER_SKIP_DOWNLOAD=true
 export DISABLE_ADMIN_COMPILATION_TYPECHECK=true
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 

--- a/shopware/administration/6.6/bin/build-administration.sh
+++ b/shopware/administration/6.6/bin/build-administration.sh
@@ -24,6 +24,7 @@ set +o allexport
 set -euo pipefail
 
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+export PUPPETEER_SKIP_DOWNLOAD=true
 export DISABLE_ADMIN_COMPILATION_TYPECHECK=true
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 

--- a/shopware/administration/6.7/bin/build-administration.sh
+++ b/shopware/administration/6.7/bin/build-administration.sh
@@ -26,6 +26,7 @@ set -euo pipefail
 
 export APP_URL
 export PROJECT_ROOT
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 export PUPPETEER_SKIP_DOWNLOAD=true
 
 if [[ -e "${PROJECT_ROOT}/vendor/shopware/platform" ]]; then

--- a/shopware/administration/6.7/bin/build-administration.sh
+++ b/shopware/administration/6.7/bin/build-administration.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 
 export APP_URL
 export PROJECT_ROOT
-export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+export PUPPETEER_SKIP_DOWNLOAD=true
 
 if [[ -e "${PROJECT_ROOT}/vendor/shopware/platform" ]]; then
     ADMIN_ROOT="${ADMIN_ROOT:-"${PROJECT_ROOT}/vendor/shopware/platform/src/Administration"}"

--- a/shopware/platform/6.4/bin/build-administration.sh
+++ b/shopware/platform/6.4/bin/build-administration.sh
@@ -21,6 +21,7 @@ set +o allexport
 set -euo pipefail
 
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+export PUPPETEER_SKIP_DOWNLOAD=true
 export DISABLE_ADMIN_COMPILATION_TYPECHECK=true
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 

--- a/shopware/platform/6.4/bin/build-storefront.sh
+++ b/shopware/platform/6.4/bin/build-storefront.sh
@@ -6,6 +6,7 @@ CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 set -euo pipefail
 
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+export PUPPETEER_SKIP_DOWNLOAD=true
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 
 if [[ -e "${PROJECT_ROOT}/vendor/shopware/platform" ]]; then

--- a/shopware/platform/6.6/bin/build-administration.sh
+++ b/shopware/platform/6.6/bin/build-administration.sh
@@ -28,6 +28,7 @@ set +o allexport
 set -euo pipefail
 
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+export PUPPETEER_SKIP_DOWNLOAD=true
 export DISABLE_ADMIN_COMPILATION_TYPECHECK=true
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 

--- a/shopware/platform/6.6/bin/build-storefront.sh
+++ b/shopware/platform/6.6/bin/build-storefront.sh
@@ -10,6 +10,7 @@ CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 set -euo pipefail
 
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+export PUPPETEER_SKIP_DOWNLOAD=true
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 export NPM_CONFIG_FUND=false
 export NPM_CONFIG_AUDIT=false

--- a/shopware/platform/6.7/bin/build-administration.sh
+++ b/shopware/platform/6.7/bin/build-administration.sh
@@ -30,7 +30,7 @@ set -euo pipefail
 
 export APP_URL
 export PROJECT_ROOT
-export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+export PUPPETEER_SKIP_DOWNLOAD=true
 
 if [[ -e "${PROJECT_ROOT}/vendor/shopware/platform" ]]; then
     ADMIN_ROOT="${ADMIN_ROOT:-"${PROJECT_ROOT}/vendor/shopware/platform/src/Administration"}"

--- a/shopware/platform/6.7/bin/build-administration.sh
+++ b/shopware/platform/6.7/bin/build-administration.sh
@@ -30,6 +30,7 @@ set -euo pipefail
 
 export APP_URL
 export PROJECT_ROOT
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 export PUPPETEER_SKIP_DOWNLOAD=true
 
 if [[ -e "${PROJECT_ROOT}/vendor/shopware/platform" ]]; then

--- a/shopware/platform/6.7/bin/build-storefront.sh
+++ b/shopware/platform/6.7/bin/build-storefront.sh
@@ -9,7 +9,7 @@ CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
 set -euo pipefail
 
-export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+export PUPPETEER_SKIP_DOWNLOAD=true
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 export NPM_CONFIG_FUND=false
 export NPM_CONFIG_AUDIT=false

--- a/shopware/platform/6.7/bin/build-storefront.sh
+++ b/shopware/platform/6.7/bin/build-storefront.sh
@@ -9,6 +9,7 @@ CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
 set -euo pipefail
 
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 export PUPPETEER_SKIP_DOWNLOAD=true
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 export NPM_CONFIG_FUND=false

--- a/shopware/storefront/6.4/bin/build-storefront.sh
+++ b/shopware/storefront/6.4/bin/build-storefront.sh
@@ -6,6 +6,7 @@ CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 set -euo pipefail
 
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+export PUPPETEER_SKIP_DOWNLOAD=true
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 
 if [[ -e "${PROJECT_ROOT}/vendor/shopware/platform" ]]; then

--- a/shopware/storefront/6.6/bin/build-storefront.sh
+++ b/shopware/storefront/6.6/bin/build-storefront.sh
@@ -6,6 +6,7 @@ CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 set -euo pipefail
 
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+export PUPPETEER_SKIP_DOWNLOAD=true
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 export NPM_CONFIG_FUND=false
 export NPM_CONFIG_AUDIT=false

--- a/shopware/storefront/6.7/bin/build-storefront.sh
+++ b/shopware/storefront/6.7/bin/build-storefront.sh
@@ -5,6 +5,7 @@ CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
 set -euo pipefail
 
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 export PUPPETEER_SKIP_DOWNLOAD=true
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 export NPM_CONFIG_FUND=false

--- a/shopware/storefront/6.7/bin/build-storefront.sh
+++ b/shopware/storefront/6.7/bin/build-storefront.sh
@@ -5,7 +5,7 @@ CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
 set -euo pipefail
 
-export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+export PUPPETEER_SKIP_DOWNLOAD=true
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 export NPM_CONFIG_FUND=false
 export NPM_CONFIG_AUDIT=false


### PR DESCRIPTION
The `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` env variable is deprecated and should be replaced with `PUPPETEER_SKIP_DOWNLOAD` to work properly

- See https://github.com/shopware/shopware/pull/18254