### PR TITLE
fix(fastly): strip cookies for static assets in vcl_recv

### DIFF
--- a/shopware/fastly-meta/6.4/config/fastly/recv/default.vcl
+++ b/shopware/fastly-meta/6.4/config/fastly/recv/default.vcl
@@ -1,3 +1,10 @@
+# Static assets don't need any cookie. Stripping them ensures a stable cache
+# key when assets are served from the same domain as the storefront, so the
+# hash does not vary based on sw-cache-hash or sw-currency.
+if (req.url.path ~ "^/(media|thumbnail|theme|bundles)/") {
+  unset req.http.Cookie;
+}
+
 # Don't allow clients to force a pass
 if (req.restarts == 0) {
   unset req.http.x-pass;

--- a/shopware/fastly-meta/6.5/config/fastly/recv/default.vcl
+++ b/shopware/fastly-meta/6.5/config/fastly/recv/default.vcl
@@ -1,3 +1,10 @@
+# Static assets don't need any cookie. Stripping them ensures a stable cache
+# key when assets are served from the same domain as the storefront, so the
+# hash does not vary based on sw-cache-hash or sw-currency.
+if (req.url.path ~ "^/(media|thumbnail|theme|bundles)/") {
+  unset req.http.Cookie;
+}
+
 # Don't allow clients to force a pass
 if (req.restarts == 0) {
   unset req.http.x-pass;

--- a/shopware/fastly-meta/6.6/config/fastly/recv/default.vcl
+++ b/shopware/fastly-meta/6.6/config/fastly/recv/default.vcl
@@ -1,3 +1,10 @@
+# Static assets don't need any cookie. Stripping them ensures a stable cache
+# key when assets are served from the same domain as the storefront, so the
+# hash does not vary based on sw-cache-hash or sw-currency.
+if (req.url.path ~ "^/(media|thumbnail|theme|bundles)/") {
+  unset req.http.Cookie;
+}
+
 # Don't allow clients to force a pass
 if (req.restarts == 0) {
   unset req.http.x-pass;

--- a/shopware/fastly-meta/6.7/config/fastly/recv/default.vcl
+++ b/shopware/fastly-meta/6.7/config/fastly/recv/default.vcl
@@ -1,3 +1,10 @@
+# Static assets don't need any cookie. Stripping them ensures a stable cache
+# key when assets are served from the same domain as the storefront, so the
+# hash does not vary based on sw-cache-hash or sw-currency.
+if (req.url.path ~ "^/(media|thumbnail|theme|bundles)/") {
+  unset req.http.Cookie;
+}
+
 # Don't allow clients to force a pass
 if (req.restarts == 0) {
   unset req.http.x-pass;

--- a/shopware/fastly-meta/6.8/config/fastly/recv/default.vcl
+++ b/shopware/fastly-meta/6.8/config/fastly/recv/default.vcl
@@ -1,3 +1,10 @@
+# Static assets don't need any cookie. Stripping them ensures a stable cache
+# key when assets are served from the same domain as the storefront, so the
+# hash does not vary based on sw-cache-hash or sw-currency.
+if (req.url.path ~ "^/(media|thumbnail|theme|bundles)/") {
+  unset req.http.Cookie;
+}
+
 # Don't allow clients to force a pass
 if (req.restarts == 0) {
   unset req.http.x-pass;


### PR DESCRIPTION
## Problem

In the Fastly VCL snippets (`shopware/fastly-meta/<version>/config/fastly/`), the hash snippet considers Shopware's HTTP cache cookies:

```vcl
# config/fastly/hash/default.vcl
if (req.http.sw-cache-hash) {
  set req.hash += req.http.sw-cache-hash;
} elseif (req.http.cookie:sw-currency) {
  set req.hash += req.http.cookie:sw-currency;
}
```

When static assets (media, thumbnails, themes, bundles) are served from the **same domain** as the storefront, requests for those assets still carry cookies such as `sw-cache-hash` / `sw-currency`. As a result the cache key for otherwise-identical static assets varies per cache-hash/currency, needlessly fragmenting the cache and lowering the hit rate.

## Fix

Static assets don't depend on any cookie, so unset the `Cookie` header at the start of `vcl_recv` for the asset paths:

```vcl
# Static assets don't need any cookie.
if (req.url.path ~ "^/(media|thumbnail|theme|bundles)/") {
  unset req.http.Cookie;
}
```

This produces a single, stable cache entry per asset regardless of the visitor's cache-hash or currency.

## Scope

Applied to `config/fastly/recv/default.vcl` for all supported Shopware versions (6.4, 6.5, 6.6, 6.7, 6.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)