### PR TITLE
fix(fastly): only set X-Forwarded-For on edge POP and first pass

### DIFF
--- a/shopware/fastly-meta/6.4/config/fastly/recv/default.vcl
+++ b/shopware/fastly-meta/6.4/config/fastly/recv/default.vcl
@@ -49,11 +49,17 @@ if (req.url != req.url.path) {
 # Normalize query arguments
 set req.url = querystring.sort(req.url);
 
-# Make sure that the client ip is forward to the client.
-if (req.http.x-forwarded-for) {
-    set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + req.http.Fastly-Client-IP;
-} else {
-    set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+# Make sure that the client ip is forwarded to the origin.
+# Only do this on the edge POP (fastly.ff.visits_this_service == 0) and on the
+# first pass (req.restarts == 0). On the shield node Fastly-Client-IP is the edge
+# POP's IP (not the real client), and on restarts the block would run again, so
+# without this guard X-Forwarded-For ends up with extra/wrong entries.
+if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    if (req.http.x-forwarded-for) {
+        set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + req.http.Fastly-Client-IP;
+    } else {
+        set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+    }
 }
 
 # Don't cache Authenticate & Authorization

--- a/shopware/fastly-meta/6.5/config/fastly/recv/default.vcl
+++ b/shopware/fastly-meta/6.5/config/fastly/recv/default.vcl
@@ -49,11 +49,17 @@ if (req.url != req.url.path) {
 # Normalize query arguments
 set req.url = querystring.sort(req.url);
 
-# Make sure that the client ip is forward to the client.
-if (req.http.x-forwarded-for) {
-    set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + req.http.Fastly-Client-IP;
-} else {
-    set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+# Make sure that the client ip is forwarded to the origin.
+# Only do this on the edge POP (fastly.ff.visits_this_service == 0) and on the
+# first pass (req.restarts == 0). On the shield node Fastly-Client-IP is the edge
+# POP's IP (not the real client), and on restarts the block would run again, so
+# without this guard X-Forwarded-For ends up with extra/wrong entries.
+if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    if (req.http.x-forwarded-for) {
+        set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + req.http.Fastly-Client-IP;
+    } else {
+        set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+    }
 }
 
 # Don't cache Authenticate & Authorization

--- a/shopware/fastly-meta/6.6/config/fastly/recv/default.vcl
+++ b/shopware/fastly-meta/6.6/config/fastly/recv/default.vcl
@@ -49,11 +49,17 @@ if (req.url != req.url.path) {
 # Normalize query arguments
 set req.url = querystring.sort(req.url);
 
-# Make sure that the client ip is forward to the client.
-if (req.http.x-forwarded-for) {
-    set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + req.http.Fastly-Client-IP;
-} else {
-    set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+# Make sure that the client ip is forwarded to the origin.
+# Only do this on the edge POP (fastly.ff.visits_this_service == 0) and on the
+# first pass (req.restarts == 0). On the shield node Fastly-Client-IP is the edge
+# POP's IP (not the real client), and on restarts the block would run again, so
+# without this guard X-Forwarded-For ends up with extra/wrong entries.
+if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    if (req.http.x-forwarded-for) {
+        set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + req.http.Fastly-Client-IP;
+    } else {
+        set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+    }
 }
 
 # Don't cache Authenticate & Authorization

--- a/shopware/fastly-meta/6.7/config/fastly/recv/default.vcl
+++ b/shopware/fastly-meta/6.7/config/fastly/recv/default.vcl
@@ -49,11 +49,17 @@ if (req.url != req.url.path) {
 # Normalize query arguments
 set req.url = querystring.sort(req.url);
 
-# Make sure that the client ip is forward to the client.
-if (req.http.x-forwarded-for) {
-    set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + req.http.Fastly-Client-IP;
-} else {
-    set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+# Make sure that the client ip is forwarded to the origin.
+# Only do this on the edge POP (fastly.ff.visits_this_service == 0) and on the
+# first pass (req.restarts == 0). On the shield node Fastly-Client-IP is the edge
+# POP's IP (not the real client), and on restarts the block would run again, so
+# without this guard X-Forwarded-For ends up with extra/wrong entries.
+if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    if (req.http.x-forwarded-for) {
+        set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + req.http.Fastly-Client-IP;
+    } else {
+        set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+    }
 }
 
 # Don't cache Authenticate & Authorization

--- a/shopware/fastly-meta/6.8/config/fastly/recv/default.vcl
+++ b/shopware/fastly-meta/6.8/config/fastly/recv/default.vcl
@@ -49,11 +49,17 @@ if (req.url != req.url.path) {
 # Normalize query arguments
 set req.url = querystring.sort(req.url);
 
-# Make sure that the client ip is forward to the client.
-if (req.http.x-forwarded-for) {
-    set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + req.http.Fastly-Client-IP;
-} else {
-    set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+# Make sure that the client ip is forwarded to the origin.
+# Only do this on the edge POP (fastly.ff.visits_this_service == 0) and on the
+# first pass (req.restarts == 0). On the shield node Fastly-Client-IP is the edge
+# POP's IP (not the real client), and on restarts the block would run again, so
+# without this guard X-Forwarded-For ends up with extra/wrong entries.
+if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    if (req.http.x-forwarded-for) {
+        set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + req.http.Fastly-Client-IP;
+    } else {
+        set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+    }
 }
 
 # Don't cache Authenticate & Authorization


### PR DESCRIPTION
## Problem

In `config/fastly/recv/default.vcl` (all versions, 6.4–6.8) the block that appends `Fastly-Client-IP` to `X-Forwarded-For` runs unconditionally:

```vcl
# Make sure that the client ip is forward to the client.
if (req.http.x-forwarded-for) {
    set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + req.http.Fastly-Client-IP;
} else {
    set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
}
```

`vcl_recv` executes on **every** Fastly node the request passes through and again on **every restart**. With shielding enabled this block therefore runs on both the edge POP and the shield node — and on the shield node `Fastly-Client-IP` is the **edge POP's IP**, not the real client. On restarts it runs again on the same node. The result is `X-Forwarded-For` carrying extra / incorrect entries (Fastly-internal IPs) by the time the request reaches the origin.

## Fix

Guard the block with Fastly's documented pattern so it runs exactly once — on the edge POP, on the first pass:

```vcl
if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
    if (req.http.x-forwarded-for) {
        set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + req.http.Fastly-Client-IP;
    } else {
        set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
    }
}
```

- `fastly.ff.visits_this_service == 0` is true only on the edge POP (it is >0 on the shield).
- `req.restarts == 0` limits it to the first pass.

The append order is intentionally **unchanged**: the genuine client IP stays at the right end of the chain, which is where Symfony/Shopware resolves the client IP from (`Request::getClientIp()` reads the chain from the right, stripping trusted proxies).

## Scope

Applied identically to `6.4`, `6.5`, `6.6`, `6.7`, `6.8`.

## References

- [Fastly — `fastly.ff.visits_this_service`](https://www.fastly.com/documentation/reference/vcl/variables/miscellaneous/fastly-ff-visits-this-service/)
- [Fastly — X-Forwarded-For](https://www.fastly.com/documentation/reference/http/http-headers/X-Forwarded-For/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)