### PR TITLE
feat: added ES configuration admin indices.

### DIFF
--- a/shopware/k8s-meta/1.0/config/packages/operator.yaml
+++ b/shopware/k8s-meta/1.0/config/packages/operator.yaml
@@ -11,8 +11,8 @@ parameters:
     env(K8S_CACHE_HOST): "localhost"
     env(K8S_CACHE_PORT): "6379"
     env(K8S_CACHE_INDEX): ""
-    env(K8S_ES_ADMIN_NUMBER_OF_SHARDS): 1
-    env(K8S_ES_ADMIN_NUMBER_OF_REPLICAS): 1
+    env(K8S_ES_ADMIN_NUMBER_OF_SHARDS): "1"
+    env(K8S_ES_ADMIN_NUMBER_OF_REPLICAS): "1"
     env(K8S_ES_NUMBER_OF_REPLICAS): null
     env(K8S_ES_NUMBER_OF_SHARDS): null
     env(PHP_SESSION_SAVE_PATH): "tcp://127.0.0.1:6379"

--- a/shopware/k8s-meta/1.0/config/packages/operator.yaml
+++ b/shopware/k8s-meta/1.0/config/packages/operator.yaml
@@ -11,6 +11,8 @@ parameters:
     env(K8S_CACHE_HOST): "localhost"
     env(K8S_CACHE_PORT): "6379"
     env(K8S_CACHE_INDEX): ""
+    env(K8S_ES_ADMIN_NUMBER_OF_SHARDS): 1
+    env(K8S_ES_ADMIN_NUMBER_OF_REPLICAS): 1
     env(K8S_ES_NUMBER_OF_REPLICAS): null
     env(K8S_ES_NUMBER_OF_SHARDS): null
     env(PHP_SESSION_SAVE_PATH): "tcp://127.0.0.1:6379"
@@ -75,6 +77,10 @@ elasticsearch:
     index_settings:
         number_of_replicas: "%env(int:K8S_ES_NUMBER_OF_REPLICAS)%"
         number_of_shards: "%env(int:K8S_ES_NUMBER_OF_SHARDS)%"
+    administration:
+        index_settings:
+            number_of_shards: "%env(int:K8S_ES_ADMIN_NUMBER_OF_SHARDS)%"
+            number_of_replicas: "%env(int:K8S_ES_ADMIN_NUMBER_OF_REPLICAS)%"
 
 
 framework:

--- a/shopware/k8s-meta/2.0/config/packages/operator.yaml
+++ b/shopware/k8s-meta/2.0/config/packages/operator.yaml
@@ -13,6 +13,8 @@ parameters:
     env(K8S_CACHE_INDEX): ""
     env(K8S_ES_NUMBER_OF_REPLICAS): null
     env(K8S_ES_NUMBER_OF_SHARDS): null
+    env(K8S_ES_ADMIN_NUMBER_OF_SHARDS): 1
+    env(K8S_ES_ADMIN_NUMBER_OF_REPLICAS): 1
     env(PHP_SESSION_SAVE_PATH): "tcp://127.0.0.1:6379"
     env(K8S_REDIS_SESSION_DSN): "redis://%env(string:key:host:url:PHP_SESSION_SAVE_PATH)%:%env(string:key:port:url:PHP_SESSION_SAVE_PATH)%/%env(string:key:path:url:PHP_SESSION_SAVE_PATH)%"
     env(K8S_REDIS_APP_DSN): "redis://%env(K8S_CACHE_HOST)%:%env(K8S_CACHE_PORT)%/%env(K8S_CACHE_INDEX)%"
@@ -72,6 +74,10 @@ elasticsearch:
     index_settings:
         number_of_replicas: "%env(int:K8S_ES_NUMBER_OF_REPLICAS)%"
         number_of_shards: "%env(int:K8S_ES_NUMBER_OF_SHARDS)%"
+    administration:
+        index_settings:
+            number_of_shards: "%env(int:K8S_ES_ADMIN_NUMBER_OF_SHARDS)%"
+            number_of_replicas: "%env(int:K8S_ES_ADMIN_NUMBER_OF_REPLICAS)%"
 
 framework:
     session:

--- a/shopware/k8s-meta/2.0/config/packages/operator.yaml
+++ b/shopware/k8s-meta/2.0/config/packages/operator.yaml
@@ -13,8 +13,8 @@ parameters:
     env(K8S_CACHE_INDEX): ""
     env(K8S_ES_NUMBER_OF_REPLICAS): null
     env(K8S_ES_NUMBER_OF_SHARDS): null
-    env(K8S_ES_ADMIN_NUMBER_OF_SHARDS): 1
-    env(K8S_ES_ADMIN_NUMBER_OF_REPLICAS): 1
+    env(K8S_ES_ADMIN_NUMBER_OF_SHARDS): "1"
+    env(K8S_ES_ADMIN_NUMBER_OF_REPLICAS): "1"
     env(PHP_SESSION_SAVE_PATH): "tcp://127.0.0.1:6379"
     env(K8S_REDIS_SESSION_DSN): "redis://%env(string:key:host:url:PHP_SESSION_SAVE_PATH)%:%env(string:key:port:url:PHP_SESSION_SAVE_PATH)%/%env(string:key:path:url:PHP_SESSION_SAVE_PATH)%"
     env(K8S_REDIS_APP_DSN): "redis://%env(K8S_CACHE_HOST)%:%env(K8S_CACHE_PORT)%/%env(K8S_CACHE_INDEX)%"


### PR DESCRIPTION
This pull request updates the Elasticsearch configuration in both `1.0` and `2.0` operator YAML files to add separate environment variables and index settings for the administration index. This allows the administration index to have its own configurable number of shards and replicas, independent from the default Elasticsearch index settings.

**Elasticsearch administration index configuration:**

* Added new environment variables `K8S_ES_ADMIN_NUMBER_OF_SHARDS` and `K8S_ES_ADMIN_NUMBER_OF_REPLICAS` with default values of `1` to the `parameters` section in both `1.0` and `2.0` operator YAML files. [[1]](diffhunk://#diff-a019c3b6407301585db50547ad2fe0c9239bfd700e5c877c66a39cd331c9ff8aR14-R15) [[2]](diffhunk://#diff-80fc77609e6816bcac067e19995ec2bab7d5f8b03cdfbf7c3a3488bbb1282c0dR16-R17)
* Updated the `elasticsearch` section to include a new `administration` subsection, allowing the administration index to have its own `number_of_shards` and `number_of_replicas` settings, which reference the new environment variables. [[1]](diffhunk://#diff-a019c3b6407301585db50547ad2fe0c9239bfd700e5c877c66a39cd331c9ff8aR80-R83) [[2]](diffhunk://#diff-80fc77609e6816bcac067e19995ec2bab7d5f8b03cdfbf7c3a3488bbb1282c0dR77-R80)